### PR TITLE
Fixed typo in events example.

### DIFF
--- a/src/examples/events.html
+++ b/src/examples/events.html
@@ -18,7 +18,7 @@
 		 
 		 - onBeforeShow: Just before the gallery is displayed
 		 - onShow: When the gallery is displayed
-		 - onBeforeShow: Just before the gallery is hidden
+		 - onBeforeHide: Just before the gallery is hidden
 		 - onHide: When the gallery is hidden
 		 - onShowNext: When the gallery has been issued the command to show the next image
 		 - onShowPrevious: When the gallery has been issued the command to show the previous image


### PR DESCRIPTION
In the event-example (`src/examples/event.html`) there is a typo-error due to copy-and-paste. Fixed it.
