### PR TITLE
Caption-Elements should not be display:block;

### DIFF
--- a/src/assets/photoswipe.css
+++ b/src/assets/photoswipe.css
@@ -68,7 +68,7 @@ div.ps-caption
 	font-family: "Lucida Grande", Helvetica, Arial,Verdana, sans-serif;
 	text-align: center;
 }
-div.ps-caption *  { display: block; }
+div.ps-caption *  { display: inline; }
 
 div.ps-caption-bottom
 { 


### PR DESCRIPTION
If all elements in the caption get display: block, a line-break is inserted after each element. This leads into problems if the caption does contain further DOM-Nodes (aka not plaintext). This might happen if you override the getImageCaption-method to return a DOM-Element. 
display:inline is the default, so why not use it?
