### PR TITLE
Allowing touch based devices to scroll when PhotoSwipe is embedded

### DIFF
--- a/src/lib/code.util-1.0.6/src/touchelement.class.js
+++ b/src/lib/code.util-1.0.6/src/touchelement.class.js
@@ -69,7 +69,8 @@
 				move: false,
 				gesture: false,
 				doubleTap: false,
-				preventDefaultTouchEvents: true
+				preventDefaultTouchEvents: true,
+				allowVerticalScroll:false
 			};
 			
 			Util.extend(this.captureSettings, captureSettings);
@@ -288,7 +289,7 @@
 		 */
 		onTouchStart: function(e){
 			
-			if (this.captureSettings.preventDefaultTouchEvents){
+			if (this.captureSettings.preventDefaultTouchEvents && !this.captureSettings.allowVerticalScroll){
 				e.preventDefault();
 			}
 			
@@ -327,9 +328,7 @@
 		 */
 		onTouchMove: function(e){
 			
-			if (this.captureSettings.preventDefaultTouchEvents){
-				e.preventDefault();
-			}
+		
 			
 			if (this.isGesture && this.captureSettings.gesture){
 				return;
@@ -339,11 +338,21 @@
 				touchEvent = Util.Events.getTouchEvent(e),
 				touches = touchEvent.touches;
 			
+			var point = this.getTouchPoint(touches);
+			
+			if(this.captureSettings.allowVerticalScroll && Math.abs(this.touchStartPoint.x - point.x) < Math.abs(this.touchStartPoint.y - point.y)){
++                return;
++            }
+			
+			if (this.captureSettings.preventDefaultTouchEvents){
+				e.preventDefault();
+			}
+			
 			Util.Events.fire(this, { 
 				type: Util.TouchElement.EventTypes.onTouch, 
 				target: this, 
 				action: Util.TouchElement.ActionTypes.touchMove,
-				point: this.getTouchPoint(touches),
+				point: point,
 				targetEl: e.target,
 				currentTargetEl: e.currentTarget
 			});
@@ -360,11 +369,7 @@
 			if (this.isGesture && this.captureSettings.gesture){
 				return;
 			}
-			
-			if (this.captureSettings.preventDefaultTouchEvents){
-				e.preventDefault();
-			}
-			
+						
 			// http://backtothecode.blogspot.com/2009/10/javascript-touch-and-gesture-events.html
 			// iOS removed the current touch from e.touches on "touchend"
 			// Need to look into e.changedTouches
@@ -373,7 +378,17 @@
 				touchEvent = Util.Events.getTouchEvent(e),
 				touches = (!Util.isNothing(touchEvent.changedTouches)) ? touchEvent.changedTouches : touchEvent.touches;
 			
+			
+			
 			this.touchEndPoint = this.getTouchPoint(touches);
+			
+			if(this.captureSettings.allowVerticalScroll && Math.abs(this.touchStartPoint.x - this.touchEndPoint.x) < Math.abs(this.touchStartPoint.y - this.touchEndPoint.y)){
++                return;
++           }
+			
+			if (this.captureSettings.preventDefaultTouchEvents){
+				e.preventDefault();
+			}
 			
 			Util.Events.fire(this, { 
 				type: Util.TouchElement.EventTypes.onTouch, 

--- a/src/photoswipe.class.js
+++ b/src/photoswipe.class.js
@@ -159,7 +159,7 @@
 				uiWebViewResetPositionDelay: 500,
 				target: window,
 				preventDefaultTouchEvents: true,
-				
+				allowVerticalScroll:false,
 				
 				// Carousel
 				loop: true,

--- a/src/uilayer.class.js
+++ b/src/uilayer.class.js
@@ -77,7 +77,8 @@
 				move: true,
 				gesture: Util.Browser.iOS,
 				doubleTap: true,
-				preventDefaultTouchEvents: this.settings.preventDefaultTouchEvents
+				preventDefaultTouchEvents: this.settings.preventDefaultTouchEvents,
+				allowVerticalScroll: this.settings.allowVerticalScroll
 			});
 			
 		},


### PR DESCRIPTION
Previously if you embedded the gallery in a custom container touch devices would have been unable to scroll since the java script was killing default events.  I added a parameter which calculates when the scroll is in a vertical direction and allows the default events to pass through, giving users on touch based devices the ability to scroll the page when the parameter is active.

Let me know if you'd prefer I rename the parameter to something more suitable within your naming scheme.
