### PR TITLE
Disable play button for galleries with one image

### DIFF
--- a/src/assets/photoswipe.css
+++ b/src/assets/photoswipe.css
@@ -161,7 +161,7 @@ div.ps-toolbar-play div.ps-toolbar-content
 }
 div.ps-toolbar-play-disabled div.ps-toolbar-content
 {
-    background-position: -88px -44px;
+	background-position: -88px -44px;
 }
 
 /* Hi-res display */

--- a/src/toolbar.class.js
+++ b/src/toolbar.class.js
@@ -455,7 +455,7 @@
 			
 			Util.DOM.removeClass(this.previousEl, PhotoSwipe.Toolbar.CssClasses.previousDisabled);
 			Util.DOM.removeClass(this.nextEl, PhotoSwipe.Toolbar.CssClasses.nextDisabled);
-            Util.DOM.removeClass(this.playEl, PhotoSwipe.Toolbar.CssClasses.playDisabled);
+			Util.DOM.removeClass(this.playEl, PhotoSwipe.Toolbar.CssClasses.playDisabled);
 			
 			if (index > 0 && index < this.cache.images.length-1){
 				return;

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -18,7 +18,7 @@
 		captionContent: 'ps-caption-content',
 		close: 'ps-toolbar-close',
 		play: 'ps-toolbar-play',
-        playDisabled: 'ps-toolbar-play-disabled',
+		playDisabled: 'ps-toolbar-play-disabled',
 		previous: 'ps-toolbar-previous',
 		previousDisabled: 'ps-toolbar-previous-disabled',
 		next: 'ps-toolbar-next',


### PR DESCRIPTION
This disables the play button on galleries that only have one image. Might not be the normal use case, but we're using PhotoSwipe on a mobile news site where stories have a variable number of photos. This allows us to present a consistent experience on every page.
