### PR TITLE
updates objectHasProperty to check for ('property' in object) // back button fix

### DIFF
--- a/src/lib/code.util-1.0.6/src/util.js
+++ b/src/lib/code.util-1.0.6/src/util.js
@@ -260,8 +260,8 @@
 		 */
 		objectHasProperty: function(obj, propName){
 			
-			if (obj.hasOwnProperty){
-				return obj.hasOwnProperty(propName);
+			if (propName in obj) {
+				return propName in obj;
 			}
 			else{
 				return ('undefined' !== typeof obj[propName]);


### PR DESCRIPTION
This change may solve some of the back button issues people are reporting. It did for us, in any case.

The "isBackEventSupported" check in photoswipe.class.js was returning false on browsers that clearly supported 'onhashchange'. Compatibility table here: http://caniuse.com/hashchange

Based on http://perfectionkills.com/detecting-event-support-without-browser-sniffing/ it looks like the best way to check for actual event support is by checking for the property in the object, as in: 

```
if ('onhashchange' in window) { // ... 
```

Feedback appreciated.
