### PR TITLE
Toolbar prev/next tapping timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Options
 
 - **nextPreviousSlideSpeed**: How fast images are displayed when the next/previous buttons are clicked in milliseconds. Default = 0 (immediately)
 
+- **nextPrevTimeout**: How long to wait before enabling the next or previous toolbar buttons in milliseconds. Useful to avoid Safari from crashing on the iPad if the next or previous buttons are tapped continuously and without interval. Default = 0 (immediately)
+
 - **preventHide**: Prevents the user closing PhotoSwipe. Also hides the "close" button from the toolbar. Useful for "exclusive mode" (see examples/08-exclusive-mode.html). Default = false
 
 - **preventSlideshow**: Prevents the slideshow being activated. Also hides the "play" button from the toolbar. Default = false

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Mon Nov 14 11:20:48 GMT 2011
-build.number=38
+#Fri Mar 09 16:35:11 BRT 2012
+build.number=39

--- a/src/photoswipe.class.js
+++ b/src/photoswipe.class.js
@@ -21,7 +21,7 @@
 		originalImages: null,
 		mouseWheelStartTime: null,
 		windowDimensions: null,
-		
+		nextPrevLocks: null,
 		
 		
 		// Components
@@ -196,7 +196,10 @@
 				getImageSource: PhotoSwipe.Cache.Functions.getImageSource,
 				getImageCaption: PhotoSwipe.Cache.Functions.getImageCaption,
 				getImageMetaData: PhotoSwipe.Cache.Functions.getImageMetaData,
-				cacheMode: PhotoSwipe.Cache.Mode.normal
+				cacheMode: PhotoSwipe.Cache.Mode.normal,
+
+				// Previous and next buttons timeout
+				nextPrevTimeout: 0
 				
 			};
 			
@@ -220,6 +223,8 @@
 			}
 			
 			this.cache = new Cache.CacheClass(images, this.settings);
+
+			this.nextPrevLocks = { next: false, previous: false };
 			
 		},
 		
@@ -1118,15 +1123,27 @@
 		 * Function: onToolbarTap
 		 */
 		onToolbarTap: function(e){
-		
+
+			var runUnlocked = function(container, type){
+				var f = container[type];
+
+				if (!container.nextPrevLocks[type]) {
+					container.nextPrevLocks[type] = true;
+					f.call(container);
+					setTimeout(function() {
+						container.nextPrevLocks[type] = false;
+					}, container.settings.nextPrevTimeout);
+				}
+			};
+
 			switch(e.action){
 				
 				case Toolbar.ToolbarAction.next:
-					this.next();
+					runUnlocked(this, 'next');
 					break;
 				
 				case Toolbar.ToolbarAction.previous:
-					this.previous();
+					runUnlocked(this, 'previous');
 					break;
 					
 				case Toolbar.ToolbarAction.close:


### PR DESCRIPTION
As a follow-up to issue #289, this commit enables one to set the time in milliseconds the toolbar's previous or next button should ignore sequential tappings (by not firing the onTap event).
