### PR TITLE
Fixed JS-crash on iOS. Added blank 2nd and 3rd arguments to call to Util.DOM.createElement()

### DIFF
--- a/src/zoompanrotate.class.js
+++ b/src/zoompanrotate.class.js
@@ -103,7 +103,7 @@
 			Util.DOM.insertBefore(this.el, uiLayer.el, parentEl);
 			
 			if (Util.Browser.iOS){
-				this.containerEl = Util.DOM.createElement('div');
+				this.containerEl = Util.DOM.createElement('div','','');
 				Util.DOM.setStyle(this.containerEl, {
 					left: 0,
 					top: 0,


### PR DESCRIPTION
To prevent screen from going blank when zooming on iOS 5.
createElement returns retval[0], which will be undefined if not all arguments are supplied.
