### PR TITLE
Hash change events not working in jquerymobile after PhotoSwipe.detatch

### DIFF
--- a/src/photoswipe.class.js
+++ b/src/photoswipe.class.js
@@ -476,7 +476,7 @@
 				Util.Events.remove(window.document, 'keydown', this.keyDownHandler);
 			}
 			
-			if (this.isBackEventSupported && this.settings.backButtonHideEnabled){
+			if (this.isBackEventSupported && this.settings.backButtonHideEnabled && this.windowHashChangeHandler!=null){
 				Util.Events.remove(window, 'hashchange', this.windowHashChangeHandler);
 			}
 			


### PR DESCRIPTION
If windowHashChangeHandler is null and we perform Util.Events.remove() then we remove all event handlers from the 'hashchange' event. This means that jquerymobile will not be able to handle history.back() and you will remain in the same page.
