### PR TITLE
Fixes missing icons-2x.png in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -254,7 +254,7 @@
 			<fileset file="${project.src.dir}/change.log"/>
 			<fileset file="${project.src.dir}/assets/photoswipe.css"/>
 			<fileset file="${project.src.dir}/assets/icons.png"/>
-			<fileset file="${project.src.dir}/assets/icons@2x.png"/>
+			<fileset file="${project.src.dir}/assets/icons-2x.png"/>
 			<fileset file="${project.src.dir}/assets/loader.gif"/>
 			<fileset file="${project.src.dir}/assets/error.gif"/>
 		</copy>


### PR DESCRIPTION
icons@2x.png was not renamed in build.xml, resulting in no icons-2x.png
file being copied to the release folder and a blank toolbar on high-res
displays.
