### PR TITLE
Fix 'fitNoUpscale' on Apple iOS retina displays

### DIFF
--- a/src/carousel.class.js
+++ b/src/carousel.class.js
@@ -244,8 +244,8 @@
 			
 			if (this.settings.imageScaleMethod === 'fitNoUpscale'){
 				
-				newWidth = imageEl.naturalWidth;
-				newHeight =imageEl.naturalHeight;
+				newWidth = imageEl.naturalWidth / Util.DOM.pixelRatio();
+				newHeight = imageEl.naturalHeight / Util.DOM.pixelRatio();
 				
 				if (newWidth > maxWidth){
 					scale = maxWidth / newWidth;

--- a/src/lib/code.util-1.0.6/src/dom.jquery.js
+++ b/src/lib/code.util-1.0.6/src/dom.jquery.js
@@ -615,8 +615,21 @@
 				}
 				//w3c
 				return window.pageYOffset;
-			}
+			},
 			
+			
+			
+			/*
+			 * Function: pixelRatio
+			 */
+			pixelRatio: function(){
+			
+				if(!window.devicePixelRatio) {
+					return 1;
+				}
+				return window.devicePixelRatio;
+			}
+
 		}
 	
 		

--- a/src/lib/code.util-1.0.6/src/dom.js
+++ b/src/lib/code.util-1.0.6/src/dom.js
@@ -709,8 +709,21 @@
 			
 				return window.pageYOffset;
 			
-			}
+			},
 			
+			
+			
+			/*
+			 * Function: pixelRatio
+			 */
+			pixelRatio: function(){
+			
+				if(!window.devicePixelRatio) {
+					return 1;
+				}
+				return window.devicePixelRatio;
+			}
+
 		}
 	
 		


### PR DESCRIPTION
Added function Util.DOM.pixelRatio() in order to correctly scale images
on Apple iOS retina displays when using 'fitNoUpscale'.
