### PR TITLE
New "wheel" event and Chrome and IE fixes

### DIFF
--- a/src/lib/code.util-1.0.6/src/events.jquery.js
+++ b/src/lib/code.util-1.0.6/src/events.jquery.js
@@ -99,7 +99,10 @@
 				
 				var delta = 0;
 				
-				if (!Util.isNothing(event.originalEvent.wheelDelta)){
+				if (!Util.isNothing(event.originalEvent.deltaY)){
+					delta = -event.originalEvent.deltaY;
+				}
+				else if (!Util.isNothing(event.originalEvent.wheelDelta)){
 					delta = event.originalEvent.wheelDelta / 120;
 				}
 				else if (!Util.isNothing(event.originalEvent.detail)){
@@ -122,7 +125,13 @@
 			
 			_normaliseMouseWheelType: function(){
 				
-				if (Util.Browser.isEventSupported('mousewheel')){
+				if (Util.Browser.isEventSupported('wheel')){
+					return 'wheel';
+				}
+				else if (Util.Browser.msie && document.documentMode > 8){
+					return 'wheel';
+				}
+				else if (Util.Browser.isEventSupported('mousewheel')){
 					return 'mousewheel';
 				}
 				return 'DOMMouseScroll';

--- a/src/lib/code.util-1.0.6/src/events.js
+++ b/src/lib/code.util-1.0.6/src/events.js
@@ -200,7 +200,10 @@
 				
 				var delta = 0;
 				
-				if (!Util.isNothing(event.wheelDelta)){
+				if (!Util.isNothing(event.deltaY)){
+					delta = -event.deltaY;
+				}
+				else if (!Util.isNothing(event.wheelDelta)){
 					delta = event.wheelDelta / 120;
 				}
 				else if (!Util.isNothing(event.detail)){
@@ -261,7 +264,10 @@
 			
 			_normaliseMouseWheelType: function(){
 				
-				if (Util.Browser.isEventSupported('mousewheel')){
+				if (Util.Browser.isEventSupported('wheel')){
+					return 'wheel';
+				}
+				else if (Util.Browser.isEventSupported('mousewheel')){
 					return 'mousewheel';
 				}
 				return 'DOMMouseScroll';
@@ -272,7 +278,7 @@
 			
 			_NATIVE_EVENTS: { 
 				click: 1, dblclick: 1, mouseup: 1, mousedown: 1, contextmenu: 1, //mouse buttons
-				mousewheel: 1, DOMMouseScroll: 1, //mouse wheel
+				wheel: 1, mousewheel: 1, DOMMouseScroll: 1, //mouse wheel
 				mouseover: 1, mouseout: 1, mousemove: 1, selectstart: 1, selectend: 1, //mouse movement
 				keydown: 1, keypress: 1, keyup: 1, //keyboard
 				orientationchange: 1, // mobile

--- a/src/photoswipe.class.js
+++ b/src/photoswipe.class.js
@@ -436,9 +436,7 @@
 			
 			}
 			
-			if (this.settings.enableMouseWheel){
-				Util.Events.add(window, 'mousewheel', this.mouseWheelHandler);
-			}
+			Util.Events.add(window.document, 'mousewheel', this.mouseWheelHandler);
 			
 			Util.Events.add(this.uiLayer, Util.TouchElement.EventTypes.onTouch, this.uiLayerTouchHandler);
 			Util.Events.add(this.carousel, Carousel.EventTypes.onSlideByEnd, this.carouselSlideByEndHandler);
@@ -480,9 +478,7 @@
 				Util.Events.remove(window, 'hashchange', this.windowHashChangeHandler);
 			}
 			
-			if (this.settings.enableMouseWheel){
-				Util.Events.remove(window, 'mousewheel', this.mouseWheelHandler);
-			}
+			Util.Events.remove(window.document, 'mousewheel', this.mouseWheelHandler);
 			
 			if (!Util.isNothing(this.uiLayer)){
 				Util.Events.remove(this.uiLayer, Util.TouchElement.EventTypes.onTouch, this.uiLayerTouchHandler);
@@ -1160,9 +1156,19 @@
 		 */
 		onMouseWheel: function(e){
 			
+			e.preventDefault();
+			
+			if(!this.settings.enableMouseWheel){
+				return;
+			}
+			
 			var 
 				delta = Util.Events.getWheelDelta(e),
 				dt = e.timeStamp - (this.mouseWheelStartTime || 0);
+			
+			if(delta === 0){
+				return;
+			}
 			
 			if (dt < this.settings.mouseWheelSpeed) {
 				return;


### PR DESCRIPTION
Adds support for the new "wheel" event and fixes various mouse wheel
related problems in Chrome and IE.
- Moved the enableMouseWheel check into the onMouseWheel handler and added e.preventDefault() to prevent vertical scrolling in IE10.
- Added mouse wheel handler to "window.document" instead of "window" to fix mouse wheel support in IE8.
- Added a delta check in the onMouseWheel handler to handle Chrome firing the mousewheel event twice, where wheelDelta isNothing the first time.
- Changed getWheelDelta and _normaliseMouseWheelType to support the new "wheel" event (the event that deprecates the legacy "mousewheel" event), which is currently supported by FF17+ and IE9+ in IE9 document mode.
