### PR TITLE
fix ios7 gesture support

### DIFF
--- a/src/lib/code.util-1.0.6/src/browser.js
+++ b/src/lib/code.util-1.0.6/src/browser.js
@@ -43,6 +43,7 @@
 			this.android = /android/i.test(this.ua);
 			this.blackberry = /blackberry/i.test(this.ua);
 			this.iOS = (/iphone|ipod|ipad/gi).test(window.navigator.platform);
+			this.iOS7 = this.iOS && (/OS 7_/i).test(navigator.userAgent);
 			this.iPad = (/ipad/gi).test(window.navigator.platform);
 			this.iPhone = (/iphone/gi).test(window.navigator.platform);
 			this.iPod = (/ipod/gi).test(window.navigator.platform);
@@ -72,6 +73,15 @@
 		 * http://perfectionkills.com/detecting-event-support-without-browser-sniffing/
 		 */
 		isEventSupported: function(eventName) {
+			/* Override gesture support detection for ios7 because it's 
+			 * moved from window to document and we can't 
+			 * just document.createElement another document 
+			 */
+			 
+			if(this.iOS7 && eventName == "gesturestart"){
+				return true;
+			}
+
 			var 
 				el = document.createElement(this._eventTagNames[eventName] || 'div'),
 				isSupported;

--- a/src/lib/code.util-1.0.6/src/touchelement.class.js
+++ b/src/lib/code.util-1.0.6/src/touchelement.class.js
@@ -113,6 +113,12 @@
 			Util.Events.add(this.el, 'mousedown', this.mouseDownHandler);
 
 			if (Util.Browser.isGestureSupported && this.captureSettings.gesture){
+				var el = this.el
+		
+				if(Util.Browser.iOS7 && el == window){
+					el = document;
+				}
+				
 				Util.Events.add(this.el, 'gesturestart', this.gestureStartHandler);
 				Util.Events.add(this.el, 'gesturechange', this.gestureChangeHandler);
 				Util.Events.add(this.el, 'gestureend', this.gestureEndHandler);


### PR DESCRIPTION
This should fix broken pinch-to-zoom on ios7 due to gesture\* events being moved from window to document.
Note that applied like this, it will (probably) still not work for custom targets.
