### PR TITLE
Fix iOS7 GestureEvent detection

### DIFF
--- a/src/lib/code.util-1.0.6/src/browser.js
+++ b/src/lib/code.util-1.0.6/src/browser.js
@@ -51,7 +51,7 @@
 			this.is3dSupported = !Util.isNothing(testEl.style.WebkitPerspective);	
 			this.isCSSTransformSupported = ( !Util.isNothing(testEl.style.WebkitTransform) || !Util.isNothing(testEl.style.MozTransform) || !Util.isNothing(testEl.style.OTransform) || !Util.isNothing(testEl.style.transformProperty) );
 			this.isTouchSupported = this.isEventSupported('touchstart');
-			this.isGestureSupported = this.isEventSupported('gesturestart');
+			this.isGestureSupported = this.isEventSupported('gesturestart') || this.iOS;
 			
 		},
 		


### PR DESCRIPTION
The detection of GestureEvent support in PhotoSwipe no longer works in
iOS7 for some reason, disabling pinch to zoom and rotate gestures.
The GestureEvent class has been available since iOS 2.0. Any iOS device
today can be upgraded to at least iOS 3.1.3, so it is safe to assume
that all iOS devices support GestureEvent.
