### PR TITLE
Added carouselTopBottomPadding option

### DIFF
--- a/src/carousel.class.js
+++ b/src/carousel.class.js
@@ -170,8 +170,8 @@
 			
 			if (this.settings.target === window){
 				width = Util.DOM.windowWidth();
-				height = Util.DOM.windowHeight();
-				top = Util.DOM.windowScrollTop()  + 'px';
+				height = Util.DOM.windowHeight() - (this.settings.carouselTopBottomPadding * 2);
+				top = (Util.DOM.windowScrollTop() + this.settings.carouselTopBottomPadding)  + 'px';
 			}
 			else{
 				width = Util.DOM.width(this.settings.target);

--- a/src/photoswipe.class.js
+++ b/src/photoswipe.class.js
@@ -173,6 +173,7 @@
 				doubleTapSpeed: 250,
 				margin: 20,
 				imageScaleMethod: 'fit', // Either "fit", "fitNoUpscale" or "zoom",
+				carouselTopBottomPadding: 0,
 				
 				
 				// Toolbar


### PR DESCRIPTION
This commit introduces an option to add top and bottom padding to image carousel.

Caption and toolbar will never be hidden in my case and I needed to display the image between toolbar and caption. 

Here's the default behavior:

![photoswipe2](https://f.cloud.github.com/assets/1431130/1394569/81d7ae56-3c2b-11e3-9ca4-92099880c583.png)

And here's the one with carouselTopBottomPadding specified :
![photoswipe](https://f.cloud.github.com/assets/1431130/1394391/d433fd4c-3c28-11e3-975c-2edd77db0af0.png)

Here's an example usage:

```
var myPhotoSwipe = $("#Gallery a").photoSwipe({ carouselTopBottomPadding : 60 });
```
