### PR TITLE
Fix flash of black when click thumb

### DIFF
--- a/src/assets/photoswipe.css
+++ b/src/assets/photoswipe.css
@@ -13,7 +13,6 @@
  
 body.ps-active, body.ps-building, div.ps-active, div.ps-building
 {
-	background: #000;
 	overflow: hidden;
 }
 body.ps-active *, div.ps-active *


### PR DESCRIPTION
Currently PhotoSwipe turns the background of the page black the moment a thumb is clicked, but before the overlay opens up, causing the background of any site with a non-black background (i.e. white) to turn black before the overlay hides it. This is incredibly ugly and distracting.
