### PR TITLE
Supporting galleries with less than 3 photos

### DIFF
--- a/src/lib/code.util-1.0.6/src/util.js
+++ b/src/lib/code.util-1.0.6/src/util.js
@@ -143,7 +143,11 @@
 		 * Function: isLikeArray
 		 */
 		isLikeArray: function(obj) { 
-			return typeof obj.length === 'number';
+			try {
+				return typeof obj.length === 'number';
+			} catch (e) {
+				return false;
+			}
 		},
 		
 		


### PR DESCRIPTION
Galleries with < 3 photos break. This addition come to treat the Obj Error, when it does not exist (thus breaks the code)
