### PR TITLE
Verify that user agent matches Android before using it

### DIFF
--- a/src/photoswipe.class.js
+++ b/src/photoswipe.class.js
@@ -131,7 +131,8 @@
 			this.originalImages = images;
 			
 			if (Util.Browser.android && !Util.Browser.firefox){
-				if (window.navigator.userAgent.match(/Android (\d+.\d+)/).toString().replace(/^.*\,/, '') >= 2.1){
+				var androidMatch = window.navigator.userAgent.match(/Android (\d+.\d+)/);
+				if (androidMatch !== null && androidMatch.toString().replace(/^.*\,/, '') >= 2.1){
 					this.isBackEventSupported = true;
 				}
 			}


### PR DESCRIPTION
This causes a problem for user agents that include `android`
(So `Util.Browser.android` is true), but they don't have a version after it.

The error is from running toString on null.
