### PR TITLE
Add loopedOver event

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -705,7 +705,9 @@ var publicMethods = {
 
 	goTo: function(index) {
 
-		index = _getLoopedId(index);
+		looped_index = _getLoopedId(index);
+		if (index !== looped_index) _shout('loopedOver');
+		index = looped_index;
 
 		var diff = index - _currentItemIndex;
 		_indexDiff = diff;

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -325,8 +325,10 @@ _registerModule('Controller', {
 
 		setContent: function(holder, index) {
 
-			if(_options.loop) {
-				index = _getLoopedId(index);
+			if(_options.loop) {		
+				looped_index = _getLoopedId(index);
+				if (index !== looped_index) _shout('loopedOver');
+				index = looped_index;
 			}
 
 			var prevItem = self.getItemAt(holder.index);


### PR DESCRIPTION
When the gallery core or item controller load the next element which is on the other end of the list, the loopedOver event can be used by the developers to update something on the page, instead of having to listen for "afterChange" and checking the index of the currItem, while keeping the index of the previous item.
This will make it easier to make custom UIs and use PS in existing systems.