### PR TITLE
Add "mainScrollAnimStart" event

### DIFF
--- a/src/js/gestures.js
+++ b/src/js/gestures.js
@@ -1014,6 +1014,8 @@ var _gestureStartTime,
 		}
 		
 		_mainScrollAnimating = true;
+		
+		_shout('mainScrollAnimStart');
 
 		_animateProp('mainScroll', _mainScrollPos.x, animateToX, finishAnimDuration, framework.easing.cubic.out, 
 			_moveMainScroll,


### PR DESCRIPTION
This event is useful in case the client wishes to perform some sort of operation (e.g. a lightweight DOM update) at the beginning of the swipe operation rather than at the end.