### PR TITLE
fixed "main" to be also able to include UI File

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,21 +31,8 @@
     "url": "https://github.com/dimsemenov/Photoswipe/issues"
   },
   "homepage": "http://photoswipe.com",
-  "main": "dist/photoswipe.js",
+  "main": "index",
   "dependencies": {
-    "grunt-autoprefixer": "^2.0.0",
-    "grunt-contrib-clean": "^0.4.1",
-    "grunt": "^0.4.5",
-    "grunt-contrib-concat": "^0.1.3",
-    "grunt-contrib-cssmin": "^0.4.2",
-    "grunt-contrib-copy": "^0.7.0",
-    "grunt-contrib-jshint": "^0.1.1",
-    "grunt-aws-s3": "^0.10.0",
-    "grunt-contrib-watch": "^0.2.0",
-    "grunt-contrib-uglify": "^0.1.2",
-    "grunt-sass": "^0.6.1",
-    "grunt-jekyll": "^0.3.9",
-    "grunt-svgmin": "^2.0.0"
   },
   "keywords": [
     "gallery",


### PR DESCRIPTION
this enables the following CommonJS require:

```js
var PhotoSwipe = require('photoswipe/dist/photoswipe.js');
var PhotoSwipeUI_Default = require('photoswipe/dist/photoswipe-ui-default.js');
```
also removed grunt stuff from the "dependencies" section, its not needed in production environements

fixes #734