### PR TITLE
Allow item alteration before checking validity

### DIFF
--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -227,11 +227,16 @@ _registerModule('Controller', {
 			index = _getLoopedId(index);
 			var item = _getItemAt(index);
 
-			if(!item || !item.src || item.loaded || item.loading) {
+			if(!item || item.loaded || item.loading) {
 				return;
 			}
 
 			_shout('gettingData', index, item);
+
+			if (!item.src) {
+				return;
+			}
+
 			_preloadImage(item);
 		},
 		initController: function() {


### PR DESCRIPTION
When using the "Responsive Images" examples, image.src is not defined until the *gettingData* event is broadcasted. This doesn't allow to preload the images correctly.