### PR TITLE
Basic modal functionality

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -39,10 +39,10 @@ var _options = {
     	}
     },
     maxSpreadZoom: 2,
+	modal: true,
 
 	// not fully implemented yet
 	scaleMode: 'fit', // TODO
-	modal: true, // TODO
 	alwaysFadeIn: false // TODO
 };
 framework.extend(_options, options);
@@ -76,7 +76,7 @@ var _isOpen,
 	_updateSizeInterval,
 	_itemsNeedUpdate,
 	_currPositionIndex = 0,
-	_offset,
+	_offset = {},
 	_slideSize = _getEmptyPoint(), // size of slide area, including spacing
 	_itemHolders,
 	_prevItemIndex,
@@ -376,7 +376,7 @@ var _isOpen,
 		}
 	},
 
-	_onPageScroll = function() {
+	_updatePageScrollOffset = function() {
 		self.setScrollOffset(0, framework.getScrollY());		
 	};
 	
@@ -471,6 +471,7 @@ var publicMethods = {
 	setScrollOffset: function(x,y) {
 		_offset.x = x;
 		_currentWindowScrollY = _offset.y = y;
+		_shout('updateScrollOffset', _offset);
 	},
 	applyZoomPan: function(zoomLevel,panX,panY) {
 		_panOffset.x = panX;
@@ -520,7 +521,7 @@ var publicMethods = {
 		// Setup global events
 		_globalEventHandlers = {
 			resize: self.updateSize,
-			scroll: _onPageScroll,
+			scroll: _updatePageScrollOffset,
 			keydown: _onKeyDown,
 			click: _onGlobalClick
 		};
@@ -556,8 +557,8 @@ var publicMethods = {
 			_isFixedPosition = false;
 		}
 		
+		template.setAttribute('aria-hidden', 'false');
 		if(_options.modal) {
-			template.setAttribute('aria-hidden', 'false');
 			if(!_isFixedPosition) {
 				template.style.position = 'absolute';
 				template.style.top = framework.getScrollY() + 'px';
@@ -664,10 +665,8 @@ var publicMethods = {
 			clearTimeout(_showOrHideTimeout);
 		}
 		
-		if(_options.modal) {
-			template.setAttribute('aria-hidden', 'true');
-			template.className = _initalClassName;
-		}
+		template.setAttribute('aria-hidden', 'true');
+		template.className = _initalClassName;
 
 		if(_updateSizeInterval) {
 			clearInterval(_updateSizeInterval);
@@ -851,7 +850,7 @@ var publicMethods = {
 
 	updateSize: function(force) {
 		
-		if(!_isFixedPosition) {
+		if(!_isFixedPosition && _options.modal) {
 			var windowScrollY = framework.getScrollY();
 			if(_currentWindowScrollY !== windowScrollY) {
 				template.style.top = windowScrollY + 'px';
@@ -872,8 +871,7 @@ var publicMethods = {
 		_viewportSize.x = self.scrollWrap.clientWidth;
 		_viewportSize.y = self.scrollWrap.clientHeight;
 
-		
-		_offset = {x:0,y:_currentWindowScrollY};//framework.getOffset(template); 
+		_updatePageScrollOffset();
 
 		_slideSize.x = _viewportSize.x + Math.round(_viewportSize.x * _options.spacing);
 		_slideSize.y = _viewportSize.y;

--- a/website/documentation/api.md
+++ b/website/documentation/api.md
@@ -228,6 +228,21 @@ pswp.listen('unbindEvents', function() { });
 // Clean up your stuff here.
 pswp.listen('destroy', function() { });
 
+// Called when the page scrolls.
+// The callback is passed an offset with properties {x: number, y: number}.
+//
+// PhotoSwipe uses the offset to determine the top-left of the template,
+// which by default is the top-left of the viewport. When using modal: false,
+// you should listen to this event (before calling .init()) and modify the offset
+// with the template's getBoundingClientRect().
+//
+// Look at the "Implementing inline gallery display" FAQ section for more info.
+pswp.listen('updateScrollOffset', function(_offset) {
+    var r = gallery.template.getBoundingClientRect();
+    _offset.x += r.left;
+    _offset.y += r.top;
+});
+
 // PhotoSwipe has a special event called pswpTap.
 // It's dispatched using default JavaScript event model.
 // So you can, for example, call stopPropagation on it.

--- a/website/documentation/faq.md
+++ b/website/documentation/faq.md
@@ -59,6 +59,47 @@ I'll try to explain why this is not implemented yet. There are two ways to make 
 
 See [issue #657](https://github.com/dimsemenov/PhotoSwipe/issues/657).
 
+### <a name="inline-gallery"></a>Implementing inline gallery display
+To implement an embedded gallery that flows with the rest of your document, follow these steps:
+
+1. Put the .pswp template inside a positioned parent element.
+2. Set `modal: false, closeOnScroll: false` options.
+3. Modify the `getThumbBoundsFn` (if you're using it) to subtract the template parent's bounding rect.
+4. Construct the PhotoSwipe.
+5. listen for the 'updateScrollOffset' event and add the template's bounding rect to the offset.
+6. `init()` the PhotoSwipe.
+
+```html
+<div style="position: relative;" class="parent">
+    <div id="gallery" class="pswp"> ... </div>
+</div>
+```
+```javascript
+var items = [...];
+var template = document.getElementById("gallery");
+var options = {
+    ...,
+    modal: false,
+    closeOnScroll: false,
+    getThumbBoundsFn: function(index) {
+        // rect was the original bounds
+        var rect = {x: ..., y: ..., w: ...},
+
+        var templateBounds = template.parentElement.getBoundingClientRect();
+        rect.x -= templateBounds.left;
+        rect.y -= templateBounds.top;
+
+        return rect;
+    }
+};
+var photoSwipe = new PhotoSwipe(template, PhotoSwipeUI_Default, items, options);
+photoSwipe.listen('updateScrollOffset', function(_offset) {
+    var r = template.getBoundingClientRect();
+    _offset.x += r.left;
+    _offset.y += r.top;
+});
+photoSwipe.init();
+```
 
 ## Known issues
 

--- a/website/documentation/options.md
+++ b/website/documentation/options.md
@@ -55,6 +55,8 @@ Object should contain three properties: `x` (X position, relative to document), 
 
 Function has one argument - `index` of the item that is opening or closing.
 
+In non-modal mode, the template's position relative to the viewport should be subtracted from `x` and `y`. Look at [the FAQ](faq.html#inline-gallery) for more information.
+
 Example that calculates position of thumbnail: 
 
 ```javascript
@@ -265,8 +267,9 @@ isClickableElement: function(el) {
 
 Function should check if the element (`el`) is clickable. If it is &ndash; PhotoSwipe will not call `preventDefault` and `click` event will pass through. Function should be as light is possible, as it's executed multiple times on drag start and drag release.
 
+### `modal` <code class="default">boolean</code> <code class="default">true</code>
 
-
+Controls whether PhotoSwipe should expand to take up the entire viewport. If false, the PhotoSwipe element will take the size of the positioned parent of the template. Take a look at [the FAQ](faq.html#inline-gallery) for more information.
 
 ## Default UI Options
 


### PR DESCRIPTION
Hey dimsemenov,

I saw there was basic work being done on a modal/non-modal option. I'm interested in having a photoswipe gallery embedded in as part of the page rather than taking up the entire space so I went ahead and made the modal option do this. Let me know if this works, and if there's anything else to add!

To use in a non-modal situation, place the template inside a positioned element and the photoswipe gallery will take up the space of the parent when opened.

Currently known bug: two-finger zoom offsets the image as if it were based off the entire screen rather than just the parent. I couldn't find where those calculations happened exactly, so the bug exists in this current state. If you could direct me to how the calculation is done I'll fix the bug. Thanks!