### PR TITLE
Add support for custom PID in history hash

### DIFF
--- a/src/js/history.js
+++ b/src/js/history.js
@@ -55,8 +55,8 @@ var _historyUpdateTimeout,
 			return params;
 		}
 
-		var vars = hash.split('&');
-		for (var i = 0; i < vars.length; i++) {
+		var i, vars = hash.split('&');
+		for (i = 0; i < vars.length; i++) {
 			if(!vars[i]) {
 				continue;
 			}
@@ -70,7 +70,7 @@ var _historyUpdateTimeout,
 			// detect custom pid in hash and search for it among the items collection
 			var searchfor = params.pid;
 			params.pid = 0; // if custom pid cannot be found, fallback to the first item
-			for(var i = 0; i < _items.length; i++) {
+			for(i = 0; i < _items.length; i++) {
 				if(_items[i].pid === searchfor) {
 					params.pid = i;
 					break;

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -66,8 +66,8 @@ var _historyUpdateTimeout,
 			}
 			params[pair[0]] = pair[1];
 		}
-		if (isNaN(params.pid)) {
-			// detect custom pid in hash (not numeric) and search for it among the items
+		if(_options.galleryPIDs) {
+			// detect custom pid in hash and search for it among the items collection
 			var searchfor = params.pid;
 			params.pid = 0; // if custom pid cannot be found, fallback to the first item
 			for(var i = 0; i < _items.length; i++) {

--- a/src/js/history.js
+++ b/src/js/history.js
@@ -71,7 +71,7 @@ var _historyUpdateTimeout,
 			var searchfor = params.pid;
 			params.pid = 0; // if custom pid cannot be found, fallback to the first item
 			for(var i = 0; i < _items.length; i++) {
-				if(_items[i].pid == params.pid) {
+				if(_items[i].pid === searchfor) {
 					params.pid = i;
 					break;
 				}

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -309,8 +309,15 @@ _registerModule('Controller', {
 		},
 
 
+		// Accepts zero-based index or custom pid property to search for
 		getItemAt: function(index) {
-			if (index >= 0) {
+			if (isNaN(index)) {
+				for(var i = 0; i < _items.length; i++) {
+					if(_items[i].pid == index) {
+						return _items[i];
+					}
+				}
+			} else if (index >= 0) {
 				return _items[index] !== undefined ? _items[index] : false;
 			}
 			return false;

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -311,13 +311,14 @@ _registerModule('Controller', {
 
 		// Accepts zero-based index or custom pid property to search for
 		getItemAt: function(index) {
-			if (isNaN(index)) {
+			if(_options.galleryPIDs) {
 				for(var i = 0; i < _items.length; i++) {
 					if(_items[i].pid === index) {
 						return _items[i];
 					}
 				}
-			} else if (index >= 0) {
+			}
+			if(index >= 0) {
 				return _items[index] !== undefined ? _items[index] : false;
 			}
 			return false;

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -313,7 +313,7 @@ _registerModule('Controller', {
 		getItemAt: function(index) {
 			if (isNaN(index)) {
 				for(var i = 0; i < _items.length; i++) {
-					if(_items[i].pid == index) {
+					if(_items[i].pid === index) {
 						return _items[i];
 					}
 				}


### PR DESCRIPTION
Custom PID aliases may be provided in the items passed when the gallery is instantiated (similar to the galleryUID option) and will be carried forward into the history hash accordingly.

To facilitate auto-opening a particular item when the page is loaded containing a hash with a custom PID alias, the getItemAt function in items-controller now detects a NaN parameter and searches the items' pid properties for it. This solution only requires slightly modifying the photoswipeParseHash function in your sample implementation script on the Getting Started doc to, e.g.:

if (!isNaN(params.pid)) {
	params.pid = parseInt(params.pid,10)-1;
	if( params.pid < 0 ) {
		params.pid = 0;
	}
}

... so that a hash with, say, "gid=1&pid=photo12345" will cleanly find and display whichever item in the gallery has the {pid: 'photo12345'} property.
