### PR TITLE
Bugfix: Placeholder now loads src rather than msrc

### DIFF
--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -431,11 +431,11 @@ _registerModule('Controller', {
 				if(framework.features.transform) {
 					
 					var placeholderClassName = 'pswp__img pswp__img--placeholder'; 
-					placeholderClassName += (item.msrc ? '' : ' pswp__img--placeholder--blank');
+					placeholderClassName += (item.src ? '' : ' pswp__img--placeholder--blank');
 
-					var placeholder = framework.createEl(placeholderClassName, item.msrc ? 'img' : '');
-					if(item.msrc) {
-						placeholder.src = item.msrc;
+					var placeholder = framework.createEl(placeholderClassName, item.src ? 'img' : '');
+					if(item.src) {
+						placeholder.src = item.src;
 					}
 					
 					_setImageSize(placeholder, item.w, item.h);


### PR DESCRIPTION
Looks like there was just a typo with this, once the placeholder is loaded it tries to insert it by using the msrc, rather than the src attribute.

I searched for msrc in the project and found nothing, so presumed a typo/refactor mistake.

Have rectified this and it now works correctly. When I use a getThumbBoundsFn the preloaded image is no longer blank.