### PR TITLE
Lazyload amount defined in preload option when changing screen size

### DIFF
--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -230,7 +230,7 @@ _registerModule('Controller', {
 			index = _getLoopedId(index);
 			var item = _getItemAt(index);
 
-			if(!item || item.loaded || item.loading) {
+			if(!item || ((item.loaded || item.loading) && !_itemsNeedUpdate)) {
 				return;
 			}
 

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -258,7 +258,7 @@ _registerModule('Controller', {
 			_listen('beforeChange', function(diff) {
 
 				var p = _options.preload,
-					isNext = diff === null ? true : (diff > 0),
+					isNext = diff === null ? true : (diff >= 0),
 					preloadBefore = Math.min(p[0], _getNumItems() ),
 					preloadAfter = Math.min(p[1], _getNumItems() ),
 					i;


### PR DESCRIPTION
When using responsive images, on screen size change, only items in itemHolders[] are loaded again and not the amount defined with the "preload" option. The items are invalidated using `invalidateCurrItems()` when image size change is needed. Also, when using different values for "before" a "after" (aka preload = [2,10]), values are inverted, hence the 2 commits.

This is specially visible when using a small browser window and switching to "full screen" or when rotating a phone.

I am unsure my commits are the correct way of dealing with the issue, therefore I didn't push the bundled javascripts.