### PR TITLE
Add horizPanStarted handler

### DIFF
--- a/src/js/gestures.js
+++ b/src/js/gestures.js
@@ -206,6 +206,8 @@ var _gestureStartTime,
 
 			} else if(_direction === 'h' && axis === 'x' && !_zoomStarted ) {
 				
+				_shout('horizPanStarted');
+				
 				if(dir) {
 					if(newOffset > _currPanBounds.min[axis]) {
 						panFriction = _options.panEndFriction;


### PR DESCRIPTION
Added a handler for the start of a horizontal pan slide change event. This event is needed to properly hide a horizontally-positioned caption on scroll.
