### PR TITLE
Change pointer events existence check method

### DIFF
--- a/src/js/framework-bridge.js
+++ b/src/js/framework-bridge.js
@@ -140,7 +140,7 @@ var framework = {
 			features.caf = window.cancelAnimationFrame;
 		}
 
-		features.pointerEvent = navigator.pointerEnabled || navigator.msPointerEnabled;
+		features.pointerEvent = 'PointerEvent' in window || navigator.msPointerEnabled;
 
 		// fix false-positive detection of old Android in new IE
 		// (IE11 ua string contains "Android 4.0")

--- a/src/js/gestures.js
+++ b/src/js/gestures.js
@@ -641,7 +641,7 @@ var _gestureStartTime,
 			if(pointerIndex > -1) {
 				releasePoint = _currPointers.splice(pointerIndex, 1)[0];
 
-				if(navigator.pointerEnabled) {
+				if('PointerEvent' in window) {
 					releasePoint.type = e.pointerType || 'mouse';
 				} else {
 					var MSPOINTER_TYPES = {
@@ -1106,7 +1106,7 @@ _registerModule('Gestures', {
 			}
 
 			if(_pointerEventEnabled) {
-				if(navigator.pointerEnabled) {
+				if('PointerEvent' in window) {
 					addEventNames('pointer', 'down', 'move', 'up', 'cancel');
 				} else {
 					// IE10 pointer events are case-sensitive


### PR DESCRIPTION
`navigator.pointerEnabled` is removed from pointer events specification [1] and the unprefixed property hasn't even seen the sunlight. Proper feature detection should be checking the exitence of event class in window, as in this pull request.

[1] https://www.w3.org/Bugs/Public/show_bug.cgi?id=22890
