### PR TITLE
'Loop' option respected on desktop (Fixes #860)

### DIFF
--- a/dist/photoswipe.js
+++ b/dist/photoswipe.js
@@ -664,9 +664,13 @@ var _isOpen,
 			keydownAction = 'close';
 		} else if(_options.arrowKeys) {
 			if(e.keyCode === 37) {
-				keydownAction = 'prev';
-			} else if(e.keyCode === 39) { 
-				keydownAction = 'next';
+				if(_options.loop || _currentItemIndex !== 0) {
+					keydownAction = 'prev';
+				}
+			} else if(e.keyCode === 39) {
+				if(_options.loop || _currentItemIndex < _getNumItems() - 1) {
+					keydownAction = 'next';
+				}
 			}
 		}
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -366,10 +366,14 @@ var _isOpen,
 			keydownAction = 'close';
 		} else if(_options.arrowKeys) {
 			if(e.keyCode === 37) {
-				keydownAction = 'prev';
-			} else if(e.keyCode === 39) { 
-				keydownAction = 'next';
-			}
+                        if(_options.loop || _currentItemIndex !== 0) {
+                              keydownAction = 'prev';
+                        }
+                  } else if(e.keyCode === 39) {
+                        if(_options.loop || _currentItemIndex < _getNumItems() - 1) {
+                              keydownAction = 'next';
+                        }
+                  }
 		}
 
 		if(keydownAction) {


### PR DESCRIPTION
Prev/next keyboard arrow keys are disabled on the first and last slide when 'loop' option is set to false (Fixes #860).

BTW - super strange tab stops of 6 on these files...!