### PR TITLE
New "appendingImage" event

### DIFF
--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -132,6 +132,8 @@ var _getItemAt,
 			item.imageAppended = true;
 			_setImageSize(item, img, (item === self.currItem && _renderMaxResolution) );
 			
+			_shout('appendingImage', index, item, img);
+			
 			baseDiv.appendChild(img);
 
 			if(keepPlaceholder) {


### PR DESCRIPTION
Hey!

When using PhotoSwipe library in my project I faced the issue with image orientation in case of embedded (base64) images. Browser fails to properly rotate that kind of image, so the only thing helped was additonal styling (adding specific css class) of the DOM image element according to needed (real) image orientation. And the only existing way of image styling that I could find was via the "imageLoadComplete" event. However in that case there's image blinking. So the solution is to add new "appendingImage" event to apply necessary styling just before the call of the appendChild method of the images container.

Hope having the new "appendingImage" event makes sense as I suppose there can be some different case when additional manipulations with image just before inserting it into the document may be necessary.

Thanks in advance.
