### PR TITLE
SvgAnimatedString no className

### DIFF
--- a/src/js/gestures.js
+++ b/src/js/gestures.js
@@ -79,12 +79,12 @@ var _gestureStartTime,
 	
 	// find the closest parent DOM element
 	_closestElement = function(el, fn) {
-	  	if(!el) {
+	  	if(!el || el === document) {
 	  		return false;
 	  	}
 
 	  	// don't search elements above pswp__scroll-wrap
-	  	if(el.className && el.className.indexOf('pswp__scroll-wrap') > -1 ) {
+	  	if(el.getAttribute('class') && el.getAttribute('class').indexOf('pswp__scroll-wrap') > -1 ) {
 	  		return false;
 	  	}
 

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -115,7 +115,7 @@ var PhotoSwipeUI_Default =
 
 			var target = e.target || e.srcElement,
 				uiElement,
-				clickedClass = target.className,
+				clickedClass = target.getAttribute('class') || '',
 				found;
 
 			for(var i = 0; i < _uiElements.length; i++) {
@@ -572,8 +572,8 @@ var PhotoSwipeUI_Default =
 			var t = e.target || e.srcElement;
 			if(
 				t && 
-				t.className && e.type.indexOf('mouse') > -1 && 
-				( t.className.indexOf('__caption') > 0 || (/(SMALL|STRONG|EM)/i).test(t.tagName) ) 
+				t.getAttribute('class') && e.type.indexOf('mouse') > -1 && 
+				( t.getAttribute('class').indexOf('__caption') > 0 || (/(SMALL|STRONG|EM)/i).test(t.tagName) ) 
 			) {
 				preventObj.prevent = false;
 			}


### PR DESCRIPTION
We use a svg icon for our close icon, this can cause an error when asking those elements for className. `getAttribute("class")` seems to work in all cases, except when the closest look up is hits a `document` -- This one is especially hard to trigger (you must be zoomed into an image and swiping.

Relavent HTML

```html
<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
  <div class="pswp__bg"></div>
  <div class="pswp__scroll-wrap">
    <div class="pswp__container">
        <div class="pswp__item"></div>
        <div class="pswp__item"></div>
        <div class="pswp__item"></div>
    </div>
    <div class="pswp__ui pswp__ui--hidden">
      <div class="pswp__top-bar">
        <button class="pswp__close-button">
          <svg class="icon icon--close icon--16 icon--white"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon--close"></use><image src="/assets/icon--close-white.png"></image></svg>
        </button>

        <div class="pswp__preloader">
          <div class="pswp__preloader__icn">
            <div class="pswp__preloader__cut">
              <div class="pswp__preloader__donut"></div>
            </div>
          </div>
        </div>
      </div>

      <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button>
      <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button>
    </div>
  </div>
</div>
```


If the whitespace removal is not :cool: let me know, i'll remove it (I intended to have it in a separate commit but I must have fat fingered it.