### PR TITLE
Uses result from addCaptionHTMLFn() to decide whether there's a caption

### DIFF
--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -674,9 +674,9 @@ var PhotoSwipeUI_Default =
 			ui.updateIndexIndicator();
 
 			if(_options.captionEl) {
-				_options.addCaptionHTMLFn(pswp.currItem, _captionContainer);
+				var captionExists = _options.addCaptionHTMLFn(pswp.currItem, _captionContainer);
 
-				_togglePswpClass(_captionContainer, 'caption--empty', !pswp.currItem.title);
+				_togglePswpClass(_captionContainer, 'caption--empty', !captionExists);
 			}
 
 			_overlayUIUpdated = true;

--- a/website/documentation/options.md
+++ b/website/documentation/options.md
@@ -322,7 +322,7 @@ timeToIdleOutside: 1000,
 // Delay until loading indicator is displayed
 loadingIndicatorDelay: 1000,
 
-// Function builds caption markup
+// Function to build caption markup; returns true if there is a caption
 addCaptionHTMLFn: function(item, captionEl, isFake) {
 	// item      - slide object
 	// captionEl - caption DOM element


### PR DESCRIPTION
Previously, depended upon existence of item.title (which will not necessarily exist for all users)
