### PR TITLE
Button doesn't fire when has a child

### DIFF
--- a/src/css/default-skin/default-skin.scss
+++ b/src/css/default-skin/default-skin.scss
@@ -48,7 +48,7 @@
 	&:hover {
 		opacity: 1;
 	}
-	
+
 	&:active {
 		outline: none;
 		opacity: 0.9;
@@ -58,6 +58,8 @@
 		padding: 0;
 		border: 0
 	}
+
+	> * { pointer-events: none; }
 }
 
 /* pswp__ui--over-close class it added when mouse is over element that should close gallery */


### PR DESCRIPTION
Like this:
`<button class="pswp__button pswp__button--close" title="Close (Esc)"><span class="icon-close"></span></button>`

This happens on android and ios.
