### PR TITLE
Fix for _listeners being used as an object when it's null

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -703,7 +703,7 @@ var publicMethods = {
 
 		_stopAllAnimations();
 
-		_listeners = null;
+		_listeners = {};
 	},
 
 	/**


### PR DESCRIPTION
https://github.com/dimsemenov/PhotoSwipe/blob/07fac524ad529e75c4debad0b004d0518d172dbe/src/js/core.js#L128 throws an error sometimes for us because `_listeners` is `null`.

We don't have any really weird usage or anything. We listen to `close` and `destroy`. When `close` is emitted, we call destroy after a timeout.