### PR TITLE
small bugfix for default ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Fixed
+- Select text in the caption area via mouse without triggering a swipe from @mgbeyer.

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -576,6 +576,7 @@ var PhotoSwipeUI_Default =
 				( t.getAttribute('class').indexOf('__caption') > 0 || (/(SMALL|STRONG|EM)/i).test(t.tagName) ) 
 			) {
 				preventObj.prevent = false;
+				_stopAllAnimations();
 			}
 		});
 


### PR DESCRIPTION
Select text in the caption area via mouse without triggering a swipe
