### PR TITLE
improvements to UI customization options

### DIFF
--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -89,6 +89,9 @@ var PhotoSwipeUI_Default =
 			getTextForShare: function( /* shareButtonData */ ) {
 				return pswp.currItem.title || '';
 			},
+			getCustomInfoForShare: function( /* shareButtonData */ ) {
+				return ''; // to be overriden by user
+			},
 				
 			indexIndicatorSep: ' / ',
 			fitControlsWidth: 1200
@@ -219,11 +222,13 @@ var PhotoSwipeUI_Default =
 		},
 		_updateShareURLs = function() {
 			var shareButtonOut = '',
+				shareButtonCurr,
 				shareButtonData,
 				shareURL,
 				image_url,
 				page_url,
-				share_text;
+				share_text,
+				custom_text;
 
 			for(var i = 0; i < _options.shareButtons.length; i++) {
 				shareButtonData = _options.shareButtons[i];
@@ -231,20 +236,24 @@ var PhotoSwipeUI_Default =
 				image_url = _options.getImageURLForShare(shareButtonData);
 				page_url = _options.getPageURLForShare(shareButtonData);
 				share_text = _options.getTextForShare(shareButtonData);
+				custom_text = _options.getCustomInfoForShare(shareButtonData);
 
 				shareURL = shareButtonData.url.replace('{{url}}', encodeURIComponent(page_url) )
 									.replace('{{image_url}}', encodeURIComponent(image_url) )
 									.replace('{{raw_image_url}}', image_url )
-									.replace('{{text}}', encodeURIComponent(share_text) );
+									.replace('{{text}}', encodeURIComponent(share_text) )
+									.replace('{{custom}}', encodeURIComponent(custom_text) );
 
-				shareButtonOut += '<a href="' + shareURL + '" target="_blank" '+
+				shareButtonCurr = '<a href="' + shareURL + '" target="_blank" '+
 									'class="pswp__share--' + shareButtonData.id + '"' +
 									(shareButtonData.download ? 'download' : '') + '>' + 
 									shareButtonData.label + '</a>';
 
 				if(_options.parseShareButtonOut) {
-					shareButtonOut = _options.parseShareButtonOut(shareButtonData, shareButtonOut);
+					shareButtonCurr = _options.parseShareButtonOut(shareButtonData, shareButtonCur);
 				}
+
+				shareButtonOut += shareButtonCurr;
 			}
 			_shareModal.children[0].innerHTML = shareButtonOut;
 			_shareModal.children[0].onclick = _openWindowPopup;

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -203,9 +203,12 @@ var PhotoSwipeUI_Default =
 
 			pswp.shout('shareLinkClick', e, target);
 
-			if( target.hasAttribute('download') ) {
-				retval = true;
-			} else if(target.href && !/^javascript:/.test(target.href)) {
+			if(target.hasAttribute('download') || target.hasAttribute('nopopup')) {
+				// if js/no-op idioms found, click handled elsewhere (e.g. shareLinkClick listener)
+				if (!/^javascript:|^#$/.test(target.href)) { 
+					retval = true; // default handling
+				}
+			} else if(target.href) {
 				window.open(target.href, 'pswp_share', 'scrollbars=yes,resizable=yes,toolbar=no,'+
 					'location=yes,width=550,height=420,top=100,left=' + 
 					(window.screen ? Math.round(screen.width / 2 - 275) : 100)  );
@@ -239,11 +242,12 @@ var PhotoSwipeUI_Default =
 									.replace('{{image_url}}', encodeURIComponent(image_url) )
 									.replace('{{raw_image_url}}', image_url )
 									.replace('{{text}}', encodeURIComponent(share_text) )
-									.replace('{{custom}}', encodeURIComponent(custom_text) );
+									.replace('{{custom}}', custom_text );
 
 				shareButtonCurr = '<a href="' + shareURL + '" target="_blank" '+
 									'class="pswp__share--' + shareButtonData.id + '"' +
-									(shareButtonData.download ? 'download' : '') + '>' + 
+									(shareButtonData.noPopup ? ' nopopup' : '') +
+									(shareButtonData.download ? ' download' : '') + '>' + 
 									shareButtonData.label + '</a>';
 
 				if(_options.parseShareButtonOut) {

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -205,7 +205,7 @@ var PhotoSwipeUI_Default =
 
 			if( target.hasAttribute('download') ) {
 				retval = true;
-			} else if(target.href && !target.href.startsWith("javascript:")) {
+			} else if(target.href && !/^javascript:/.test(target.href)) {
 				window.open(target.href, 'pswp_share', 'scrollbars=yes,resizable=yes,toolbar=no,'+
 					'location=yes,width=550,height=420,top=100,left=' + 
 					(window.screen ? Math.round(screen.width / 2 - 275) : 100)  );

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -198,27 +198,24 @@ var PhotoSwipeUI_Default =
 
 		_openWindowPopup = function(e) {
 			e = e || window.event;
-			var target = e.target || e.srcElement;
+			var target = e.target || e.srcElement,
+			    retval = false;
 
 			pswp.shout('shareLinkClick', e, target);
 
-			if(!target.href) {
-				return false;
-			}
-
 			if( target.hasAttribute('download') ) {
-				return true;
+				retval = true;
+			} else if(target.href && !target.href.startsWith("javascript:")) {
+				window.open(target.href, 'pswp_share', 'scrollbars=yes,resizable=yes,toolbar=no,'+
+					'location=yes,width=550,height=420,top=100,left=' + 
+					(window.screen ? Math.round(screen.width / 2 - 275) : 100)  );
 			}
-
-			window.open(target.href, 'pswp_share', 'scrollbars=yes,resizable=yes,toolbar=no,'+
-										'location=yes,width=550,height=420,top=100,left=' + 
-										(window.screen ? Math.round(screen.width / 2 - 275) : 100)  );
 
 			if(!_shareModalHidden) {
 				_toggleShareModal();
 			}
 			
-			return false;
+			return retval;
 		},
 		_updateShareURLs = function() {
 			var shareButtonOut = '',
@@ -250,7 +247,7 @@ var PhotoSwipeUI_Default =
 									shareButtonData.label + '</a>';
 
 				if(_options.parseShareButtonOut) {
-					shareButtonCurr = _options.parseShareButtonOut(shareButtonData, shareButtonCur);
+					shareButtonCurr = _options.parseShareButtonOut(shareButtonData, shareButtonCurr);
 				}
 
 				shareButtonOut += shareButtonCurr;

--- a/website/documentation/api.md
+++ b/website/documentation/api.md
@@ -277,9 +277,11 @@ pswp.listen('shareLinkClick', function(e, target) {
 	// e - original click event
 	// target - link that was clicked
 
-	// If `target` has `href` attribute and 
-	// does not have `download` attribute - 
-	// share modal window will popup
+	// Share modal window will popup with target.href contents
+	// unless `target` has `href` attribute starting 
+	// with `javascript:` (e.g. `javascript:void(0);`) or
+	// `target` has the `download` attribute (in which case
+	// the href is downloaded).
 });
 
 

--- a/website/documentation/options.md
+++ b/website/documentation/options.md
@@ -377,6 +377,11 @@ indexIndicatorSep: ' / ',
 // {{image_url}}       - encoded image url
 // {{raw_image_url}}   - raw image url
 // {{custom}}          - customizable for your use
+//
+// Options: 
+// download: true  - url is a file to download; no popup window opened.
+// noPopup: true   - don't open a popup window; if the url starts with 'javascript:' or is '#', then
+//                   no action is performed (use e.g. 'shareLinkClick' listener to handle) 
 shareButtons: [
 	{id:'facebook', label:'Share on Facebook', url:'https://www.facebook.com/sharer/sharer.php?u={{url}}'},
 	{id:'twitter', label:'Tweet', url:'https://twitter.com/intent/tweet?text={{text}}&url={{url}}'},
@@ -404,7 +409,7 @@ getTextForShare: function( shareButtonData ) {
 	return pswp.currItem.title || '';
 },
 getCustomInfoForShare: function( shareButtonData ) {
-	return ''; // override for your use
+	return ''; // override for your use; use encodeURIComponent() if it will be used within a URL
 },
 
 

--- a/website/documentation/options.md
+++ b/website/documentation/options.md
@@ -376,6 +376,7 @@ indexIndicatorSep: ' / ',
 // {{text}}            - title
 // {{image_url}}       - encoded image url
 // {{raw_image_url}}   - raw image url
+// {{custom}}          - customizable for your use
 shareButtons: [
 	{id:'facebook', label:'Share on Facebook', url:'https://www.facebook.com/sharer/sharer.php?u={{url}}'},
 	{id:'twitter', label:'Tweet', url:'https://twitter.com/intent/tweet?text={{text}}&url={{url}}'},
@@ -402,6 +403,10 @@ getPageURLForShare: function( shareButtonData ) {
 getTextForShare: function( shareButtonData ) {
 	return pswp.currItem.title || '';
 },
+getCustomInfoForShare: function( shareButtonData ) {
+	return ''; // override for your use
+},
+
 
 // Parse output of share links
 parseShareButtonOut: function(shareButtonData, shareButtonOut) {


### PR DESCRIPTION
parseShareButtonOut() now gets markup for a single share button rather than a growing string of markup for all buttons. I believe this was the intended functionality (as it was, each call to that function was passed the markup for all buttons processed up until that point). 

Adds a new getCustomInfoForShare() to allow users to insert custom data in URLs. This is useful for various purposes, eg, passing the image geolocation in order to link to a map.

Updates documentation to reflect these changes.
