### PR TITLE
Added simple video support

### DIFF
--- a/src/css/default-skin/default-skin.scss
+++ b/src/css/default-skin/default-skin.scss
@@ -122,6 +122,10 @@
 	background-position: -132px 0;
 }
 
+.pswp__button--video {
+  background-position: -138px -38px;
+}
+
 /* no arrows on touch screens */
 .pswp--touch {
 	.pswp__button--arrow--left,

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -208,3 +208,102 @@
 	color: $pswp__error-text-color;
 	text-decoration: underline;
 }
+
+
+/*
+video wrapper and other video related elemenst
+*/
+.pswp__zoom-wrap--video {
+  text-align: center;
+
+  &:before {
+    content: '';
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+  }
+}
+
+.pswp__video-wrap {
+  line-height: 0;
+  width: 100%;
+  max-width: 900px;
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 auto;
+  text-align: center;
+  z-index: 1045;
+
+  img {
+    max-width: 100%;
+    max-height: 100%;
+    cursor: pointer;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-top: 40px solid rgba(0, 0, 0, 0);
+    border-bottom: 40px solid rgba(0, 0, 0, 0);
+    border-left: 60px solid rgb(255, 255, 255);
+
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    cursor: pointer;
+
+    opacity: 0.75;
+    transition: opacity $pswp__controls-transition-duration;
+  }
+
+  &:hover:after {
+    opacity: 1;
+  }
+}
+
+.pswp__video-spacer {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  padding-top: 25px;
+  height: 0;
+  width: 100%;
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.pswp__video-wrap--playing {
+  .pswp__video-spacer {
+    display: block;
+  }
+  .pswp__video {
+    display: none;
+  }
+  &:after {
+    content: none;
+  }
+}
+
+@media (min-aspect-ratio: 16/9) and (max-width: 900px) {
+  .pswp__video-wrap {
+    height: 100%;
+  }
+
+  .pswp__video-wrap--playing {
+    padding: 52px 0 44px;
+
+    .pswp__video-spacer {
+      padding-bottom: 0;
+      height: 100%;
+    }
+  }
+}

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -367,6 +367,60 @@ _registerModule('Controller', {
 				}
 			}
 
+            if (!item.src && item.video) {
+                framework.addClass(baseDiv, 'pswp__zoom-wrap--video');
+                
+                var videoWrap = framework.createEl('pswp__video-wrap', 'div');
+
+                var _videoImg;
+                item.videoPlaying = false;
+                if (item.videoImg) {
+                    _videoImg = '<img src="'+ item.videoImg +'" class="pswp__video" />'
+                } else {
+                    _videoImg = '<span class="pswp__video" ></span>'
+                }
+
+                videoWrap.innerHTML = _videoImg;
+
+                baseDiv.appendChild(videoWrap);
+
+                var _toggleVideo = item.toggleVideo = function(e){
+                    if (e) {
+                        e.stopPropagation();
+                    }
+
+                    item.videoPlaying = !item.videoPlaying;
+                    if (item.videoPlaying) {
+                        videoWrap.innerHTML = item.video;
+                        framework.addClass(videoWrap, 'pswp__video-wrap--playing');
+                    } else {
+                        videoWrap.innerHTML = _videoImg;
+                        framework.removeClass(videoWrap, 'pswp__video-wrap--playing');
+                    }
+
+                    self.ui.update();
+                };
+
+                framework.bind(videoWrap, 'pswpTap', _toggleVideo);
+
+                _listen('beforeChange', function(diff) {
+                    var prevItem = self.getItemAt(_currentItemIndex - diff);
+                    if (prevItem.videoPlaying) {
+                        prevItem.toggleVideo();
+                    }
+                });
+
+                _listen('close', function() {
+                    if (self.currItem.videoPlaying) {
+                        self.currItem.toggleVideo();
+                    }
+                });
+
+                _listen('unbindEvents', function() {
+                    framework.unbind(videoWrap, 'pswpTap', _toggleVideo);
+                });
+            }
+
 			_checkForError(item);
 
 			_calculateItemSize(item, _viewportSize);

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -36,6 +36,8 @@ var PhotoSwipeUI_Default =
 		_isIdle,
 		_listen,
 
+        _videoButton,
+
 		_loadingIndicator,
 		_loadingIndicatorHidden,
 		_loadingIndicatorTimeout,
@@ -67,6 +69,7 @@ var PhotoSwipeUI_Default =
 			counterEl: true,
 			arrowEl: true,
 			preloaderEl: true,
+            videoEl: true,
 
 			tapToClose: false,
 			tapToToggleControls: true,
@@ -486,8 +489,19 @@ var PhotoSwipeUI_Default =
 			onInit: function(el) {  
 				_loadingIndicator = el;
 			} 
-		}
-
+		},
+        {
+            name: 'button--video',
+            option: 'videoEl',
+            onInit: function (el) {
+                _videoButton = el;
+            },
+            onTap: function () {
+                if (pswp.currItem.videoPlaying) {
+                    pswp.currItem.toggleVideo();
+                }
+            }
+        }
 	];
 
 	var _setupUIElements = function() {
@@ -678,6 +692,8 @@ var PhotoSwipeUI_Default =
 
 				_togglePswpClass(_captionContainer, 'caption--empty', !pswp.currItem.title);
 			}
+         
+            _togglePswpClass(_videoButton, 'element--disabled', !pswp.currItem.videoPlaying);
 
 			_overlayUIUpdated = true;
 


### PR DESCRIPTION
Added simple video support with two video modes:
- "preview mode" which allows swipe navigation and shows video icon over video preview
- "playing mode" which replaces video preview image with custom html containing youtube iframe or any other video and shows an icon in top toolbar to control video mode

Added video button to default ui, that allows to toggle currently playing video to preview mode.

Example item in items array:

```
var items = [
    {
        videoImg: 'http://img.youtube.com/vi/wvUQcnfwUUM/hqdefault.jpg',
        video: '<div class="pswp__video-spacer"><iframe width="960" height="640" src="https://www.youtube.com/embed/wvUQcnfwUUM?autoplay=1" frameborder="0" allowfullscreen></iframe></div>'
    },
    ...
]
```

ui video button template:

```
<button class="pswp__button pswp__button--video" title="Video control"></button>
```
