### PR TITLE
do not open a popup when there is a mailto: share link, or when nopopup:true is set

### DIFF
--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -207,6 +207,11 @@ var PhotoSwipeUI_Default =
 				return true;
 			}
 
+			if( target.hasAttribute('nopopup') || target.href.startsWith("mailto:") ) {
+				location.href = target.href;
+				return false;
+			}
+
 			window.open(target.href, 'pswp_share', 'scrollbars=yes,resizable=yes,toolbar=no,'+
 										'location=yes,width=550,height=420,top=100,left=' + 
 										(window.screen ? Math.round(screen.width / 2 - 275) : 100)  );


### PR DESCRIPTION
If you add a share button to share via e-mail, you do not want to send it through window.popup as it will trigger both a new email window and an empty popup. In these situations you want to use location.href directly and let the browser handle it.

That's why I added two checks:

* If a sharing url starts with mailto:, never open a popup
* if a user explicitly sets nopopup, it will also not open a popup

If either of these conditions are true, I set location.href directly as opposed to opening a popup.