### PR TITLE
Tiny issue with "pswp__counter" on RTL sites

### DIFF
--- a/dist/default-skin/default-skin.css
+++ b/dist/default-skin/default-skin.css
@@ -254,7 +254,8 @@ a.pswp__share--download:hover {
   line-height: 44px;
   color: #FFF;
   opacity: 0.75;
-  padding: 0 10px; }
+  padding: 0 10px;
+  direction: ltr; }
 
 /*
 	


### PR DESCRIPTION
Today in RTL sites the counter direction **flip**:
**12/1.....12/2...**

But the counter should look like this (left to right) also in RTL mode.
**1/12....2/12....**

So i added direction: ltr; 

