### PR TITLE
Added rotation based on provided EXIF orientation data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ website/dist/
 /.idea
 .node-version
 .sass-cache/
-
+.project
 
 
 

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -208,3 +208,28 @@
 	color: $pswp__error-text-color;
 	text-decoration: underline;
 }
+
+/*
+	Rotation styles (for EXIF orientation handling)
+*/
+.pswp__rotate90 {
+  transform: rotate(90deg) translateY(-100%);
+  -webkit-transform: rotate(90deg) translateY(-100%);
+  -ms-transform: rotate(90deg) translateY(-100%);
+  transform-origin: top left;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+}
+.pswp__rotate180 {
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+}
+.pswp__rotate270 {
+  transform: rotate(270deg) translateX(-100%);
+  -webkit-transform: rotate(270deg) translateX(-100%);
+  -ms-transform: rotate(270deg) translateX(-100%);
+  transform-origin: top left;
+  -webkit-transform-origin: top left;
+  -ms-transform-origin: top left;
+}

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -245,7 +245,7 @@ var _getItemAt,
 				var rotationDeg = rotationMap[orientation];
 				item.rotationDeg = rotationDeg;
 				var flipDim = rotationDeg && rotationDeg % 180 == 90;
-				if (flipDim) {
+				if (flipDim && !item.hasFlippedDimensions) {
 					var w = item.w;
 					item.w = item.h;
 					item.h = w;

--- a/website/documentation/getting-started.md
+++ b/website/documentation/getting-started.md
@@ -200,7 +200,7 @@ At the end you should get something like this:
 
 Each object in the array should contain data about slide, it can be anything that you wish to display in PhotoSwipe - path to image, caption string, number of shares, comments, etc.
 
-By default PhotoSwipe uses just 5 properties: `src` (path to image), `w` (image width), `h` (image height), `msrc` (path to small image placeholder, large image will be loaded on top), `html` (custom HTML, [more about it](custom-html-in-slides.html)). 
+By default PhotoSwipe uses just 6 properties: `src` (path to image), `w` (image width), `h` (image height), `msrc` (path to small image placeholder, large image will be loaded on top), `html` (custom HTML, [more about it](custom-html-in-slides.html)) and `exif_orientation` (EXIF metadata on image orientation, see comment below). 
 
 During the navigation, PhotoSwipe adds its own properties to this object (like `minZoom` or `loaded`).
 
@@ -223,7 +223,13 @@ var slides = [
 
 		title: 'Image Caption'  // used by Default PhotoSwipe UI
 								// if you skip it, there won't be any caption
-								
+		
+		exif_orientation: 6 // can be used to provide EXIF metadata on the orientation 
+		             // of the image, which is used to transform the image for display.
+						// Specifically, the values 3, 6 and 8, which specify rotations
+						// of 180°, 90° and 270° respectively, are handled.
+						// Other EXIF orientations additionally specify that the image must
+						// be flipped along an axis, which is currently unhandled.
 
 		// You may add more properties here and use them.
 		// For example, demo gallery uses "author" property, which is used in the caption.


### PR DESCRIPTION
I added support for dynamically rotating images when given the new item property 'exif_orientation', which can easily be provided by a backend that interprets the EXIF metadata.