### PR TITLE
Animated transitions

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -743,22 +743,30 @@ var publicMethods = {
 
 	goTo: function(index) {
 
-		index = _getLoopedId(index);
+		if ( _options.animateTransitions ) {
 
-		var diff = index - _currentItemIndex;
-		_indexDiff = diff;
+			
 
-		_currentItemIndex = index;
-		self.currItem = _getItemAt( _currentItemIndex );
-		_currPositionIndex -= diff;
-		
-		_moveMainScroll(_slideSize.x * _currPositionIndex);
-		
+		} else {
 
-		_stopAllAnimations();
-		_mainScrollAnimating = false;
+			index = _getLoopedId(index);
 
-		self.updateCurrItem();
+			var diff = index - _currentItemIndex;
+			_indexDiff = diff;
+
+			_currentItemIndex = index;
+			self.currItem = _getItemAt( _currentItemIndex );
+			_currPositionIndex -= diff;
+
+			_moveMainScroll(_slideSize.x * _currPositionIndex);
+
+			_stopAllAnimations();
+			_mainScrollAnimating = false;
+
+			self.updateCurrItem();
+
+		}
+
 	},
 	next: function() {
 		self.goTo( _currentItemIndex + 1);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -745,7 +745,20 @@ var publicMethods = {
 
 		if ( _options.animateTransitions ) {
 
-			
+			_finishSwipeMainScrollGesture('swipe', (80*dir), {
+				lastFlickDist: {
+					x : 80,
+					y: 0
+				},
+				lastFlickOffset: {
+					x : (80*dir),
+					y: 0
+				},
+				lastFlickSpeed: {
+					x : (2*dir),
+					y: 0
+				}
+			});
 
 		} else {
 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -29,6 +29,7 @@ var _options = {
 	arrowKeys: true,
 	mainScrollEndFriction: 0.35,
 	panEndFriction: 0.35,
+	animateTransitions: false,
 	isClickableElement: function(el) {
         return el.tagName === 'A';
     },

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -782,10 +782,18 @@ var publicMethods = {
 
 	},
 	next: function() {
-		self.goTo( _currentItemIndex + 1);
+		if ( _options.animateTransitions ) {
+			self.goTo( -1 );
+		} else {
+			self.goTo( _currentItemIndex + 1);
+		}
 	},
 	prev: function() {
-		self.goTo( _currentItemIndex - 1);
+		if ( _options.animateTransitions ) {
+			self.goTo( 1 );
+		} else {
+			self.goTo( _currentItemIndex - 1);
+		}
 	},
 
 	// update current zoom/pan objects

--- a/src/js/gestures.js
+++ b/src/js/gestures.js
@@ -770,7 +770,8 @@ var _gestureStartTime,
 
 		// main scroll 
 		if(  (_mainScrollShifted || _mainScrollAnimating) && numPoints === 0) {
-			var itemChanged = _finishSwipeMainScrollGesture(gestureType, _releaseAnimData);
+			var totalShiftDist = _currPoint.x - _startPoint.x,
+			var itemChanged = _finishSwipeMainScrollGesture(gestureType, totalShiftDist, _releaseAnimData);
 			if(itemChanged) {
 				return;
 			}
@@ -947,7 +948,7 @@ var _gestureStartTime,
 	},
 
 
-	_finishSwipeMainScrollGesture = function(gestureType, _releaseAnimData) {
+	_finishSwipeMainScrollGesture = function(gestureType, totalShiftDist, _releaseAnimData) {
 		var itemChanged;
 		if(!_mainScrollAnimating) {
 			_currZoomedItemIndex = _currentItemIndex;
@@ -958,8 +959,7 @@ var _gestureStartTime,
 		var itemsDiff;
 
 		if(gestureType === 'swipe') {
-			var totalShiftDist = _currPoint.x - _startPoint.x,
-				isFastLastFlick = _releaseAnimData.lastFlickDist.x < 10;
+			var isFastLastFlick = _releaseAnimData.lastFlickDist.x < 10;
 
 			// if container is shifted for more than MIN_SWIPE_DISTANCE, 
 			// and last flick gesture was in right direction


### PR DESCRIPTION
Over the past couple years, the option to have images change with a slide transition effect has been requested multiple times #660, #519, #487, #1226. This has been rejected for performance reasons. However, there is already an animation engine built into PhotoSwipe. When a user drags and releases, the image is animated sideways. All we need to do is tap into this pre-built functionality.

I have done that by adding a new option called `animateTransitions`, which is checked in the public API functions of `next`, `prev`, and `goTo`. If `animateTransitions` is set to `true` (it is `false` by default for backwards compatibility), `next` and `prev`, which just are wrappers for `goTo`, use the built in animation engine to change the slide.

This is accomplished by using the `_finishSwipeMainScrollGesture` private function.

Pros:

Very little changes to codebase. No event listeners, just an option, conditionals, and changing one global to a parameter.

Cons:

Could theoretically impact performance. However, any performance issues already exist due to touch dragging. It's up to the user to not use massive images.