### PR TITLE
Add style key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "http://photoswipe.com",
   "main": "dist/photoswipe.js",
+  "style": "dist/photoswipe.css",
   "keywords": [
     "gallery",
     "lightbox",


### PR DESCRIPTION
This would allow plugins like `postcss-import`, `npm-css`, `rework-npm`, `npm-less` and lots of more to easier import the main css file. This is not a standard but used by big projects like [normalize.css](https://github.com/necolas/normalize.css) and [bootstrap](https://github.com/twbs/bootstrap/)

Let’s you do `@import "photoswipe";` instead of `@import "photoswipe/dist/main.css";`