### PR TITLE
Pswp crash with responsive images and html

### DIFF
--- a/website/documentation/responsive-images.md
+++ b/website/documentation/responsive-images.md
@@ -136,5 +136,7 @@ gallery.init();
 
 
 
+
+
 Know how this guide can be improved? [Suggest an edit!](https://github.com/dimsemenov/PhotoSwipe/blob/master/website/documentation/responsive-images.md)
 


### PR DESCRIPTION
When you want to serve responsive images and, in the same gallery, also html pages, the gettingData event crashes as it doesn't find the var item.originalImage and/or item.mediumImage. Note that I am not a very skilled programmer, just a beginner that is building his own personal website (so I don't know exactly if my solution is valid or there is a better one), anyway I noticed console in that case says that item.originalImage (or item.mediumImage) is undefined. I have solved wrapping, inside the gettingData event, the if statement by another if statement, i.e.:

// gettingData event fires each time PhotoSwipe retrieves image source & size
gallery.listen('gettingData', function(index, item) {
    if (typeof item.originalImage != 'undefined' && typeof item.mediumImage != 'undefined') { /*I added this if statement*/
    // Set image source & size based on real viewport width
        if( useLargeImages ) {
            item.src = item.originalImage.src;
            item.w = item.originalImage.w;
            item.h = item.originalImage.h;
        } else {
            item.src = item.mediumImage.src;
            item.w = item.mediumImage.w;
            item.h = item.mediumImage.h;
        }

        // It doesn't really matter what will you do here,
        // as long as item.src, item.w and item.h have valid values.
        //
        // Just avoid http requests in this listener, as it fires quite often
       } // this is the if closing bracket
    });

As I stated above I don't know if the if statement is in the correct position, or if there is another way to solve this problem, anyway adding this line PhotoSwipe works.
Kind regards,
Federico