### PR TITLE
Remove html contents more gracefully

### DIFF
--- a/src/js/framework-bridge.js
+++ b/src/js/framework-bridge.js
@@ -26,6 +26,11 @@ var framework = {
 		}
 		return el;
 	},
+	resetEl: function(el) {
+		while(el.firstChild) {
+			el.removeChild(el.firstChild);
+		}
+	},
 	getScrollY: function() {
 		var yOffset = window.pageYOffset;
 		return yOffset !== undefined ? yOffset : document.documentElement.scrollTop;

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -177,7 +177,7 @@ var _getItemAt,
 		if(item.src && item.loadError && item.container) {
 
 			if(cleanUp) {
-				item.container.innerHTML = '';
+				framework.resetEl(item.container);
 			}
 
 			item.container.innerHTML = _options.errorMsg.replace('%url%',  item.src );
@@ -344,7 +344,7 @@ _registerModule('Controller', {
 				img;
 			
 			if(!item) {
-				holder.el.innerHTML = '';
+				framework.resetEl(holder.el);
 				return;
 			}
 
@@ -478,7 +478,7 @@ _registerModule('Controller', {
 				_applyZoomPanToItem(item);
 			}
 
-			holder.el.innerHTML = '';
+			framework.resetEl(holder.el);
 			holder.el.appendChild(baseDiv);
 		},
 

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -52,7 +52,7 @@ var PhotoSwipeUI_Default =
 			
 			addCaptionHTMLFn: function(item, captionEl /*, isFake */) {
 				if(!item.title) {
-					captionEl.children[0].innerHTML = '';
+					framework.resetEl(captionEl.firstChild);
 					return false;
 				}
 				captionEl.children[0].innerHTML = item.title;


### PR DESCRIPTION
Loops through children of element to avoid older browser bugs with innerHTML.
<=IE11 was also removing subchildren