### PR TITLE
Allow natural image dimensions to override passed in width and height

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -29,6 +29,8 @@ var _options = {
 	arrowKeys: true,
 	mainScrollEndFriction: 0.35,
 	panEndFriction: 0.35,
+	// Allows for overriding the passed in width/height values with the actual image width/height once it has downloaded.
+	useNaturalDimensionsOverride: false,
 	isClickableElement: function(el) {
         return el.tagName === 'A';
     },

--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -154,6 +154,26 @@ var _getItemAt,
 		var onComplete = function() {
 			item.loading = false;
 			item.loaded = true;
+			var shouldUpdateSize = false;
+
+			if (_options.useNaturalDimensionsOverride && item.naturalDimensionsSet !== true) {
+				// Attempt to use the actual width/height of the image regardless of what was initially specified.
+				item.naturalDimensionsSet = true;
+
+				if (this.naturalWidth && item.w !== this.naturalWidth) {
+					item.w = this.naturalWidth;
+					shouldUpdateSize = true;
+				}
+
+				if (this.naturalHeight && item.h !== this.naturalHeight) {
+					item.h = this.naturalHeight;
+					shouldUpdateSize = true;
+				}
+
+				if (shouldUpdateSize) {
+					self.updateSize(true);
+				}
+			}
 
 			if(item.loadComplete) {
 				item.loadComplete(item);


### PR DESCRIPTION
Currently, if you want to make use of images of which you don't have the width and height for beforehand, then your only option is to guess and or set default width/height values. When you're dealing with images that have varying aspect ratios it basically makes them unusable. This code adds an option to specify that you would like to allow for natural image dimensions to override whatever width and height were passed in. Once an image has been downloaded we have access to the *naturalWidth* and *naturalHeight* values on the image element.

The browser support at this time is excellent:

http://caniuse.com/#search=naturalWidth