### PR TITLE
Feature: Extended the barsSize option to add space around the fullscreen image

### DIFF
--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -34,12 +34,12 @@ var _getItemAt,
 		var bounds = item.bounds;
 
 		// position of element when it's centered
-		bounds.center.x = Math.round((_tempPanAreaSize.x - realPanElementW) / 2);
+		bounds.center.x = Math.round((_tempPanAreaSize.x - realPanElementW) / 2) + item.hGap.left;
 		bounds.center.y = Math.round((_tempPanAreaSize.y - realPanElementH) / 2) + item.vGap.top;
 
 		// maximum pan position
 		bounds.max.x = (realPanElementW > _tempPanAreaSize.x) ? 
-							Math.round(_tempPanAreaSize.x - realPanElementW) : 
+							Math.round(_tempPanAreaSize.x - realPanElementW) + item.hGap.left:
 							bounds.center.x;
 		
 		bounds.max.y = (realPanElementH > _tempPanAreaSize.y) ? 
@@ -47,7 +47,7 @@ var _getItemAt,
 							bounds.center.y;
 		
 		// minimum pan position
-		bounds.min.x = (realPanElementW > _tempPanAreaSize.x) ? 0 : bounds.center.x;
+		bounds.min.x = (realPanElementW > _tempPanAreaSize.x) ? item.hGap.left : bounds.center.x;
 		bounds.min.y = (realPanElementH > _tempPanAreaSize.y) ? item.vGap.top : bounds.center.y;
 	},
 	_calculateItemSize = function(item, viewportSize, zoomLevel) {
@@ -59,12 +59,17 @@ var _getItemAt,
 				if(!item.vGap) {
 					item.vGap = {top:0,bottom:0};
 				}
+				if(!item.hGap) {
+				  item.hGap = {left:0,right:0};
+				}
 				// allows overriding vertical margin for individual items
 				_shout('parseVerticalMargin', item);
+				// allows overriding horizontal margin for individual items
+				_shout('parseHorizontalMargin', item);
 			}
 
 
-			_tempPanAreaSize.x = viewportSize.x;
+			_tempPanAreaSize.x = viewportSize.x - item.hGap.left - item.hGap.right;
 			_tempPanAreaSize.y = viewportSize.y - item.vGap.top - item.vGap.bottom;
 
 			if (isInitial) {

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -363,6 +363,9 @@ var PhotoSwipeUI_Default =
 			} else {
 				gap.top = gap.bottom = 0;
 			}
+
+      item.hGap.left = bars.left;
+      item.hGap.right = bars.right;
 		},
 		_setupIdle = function() {
 			// Hide controls when mouse is used

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -336,10 +336,10 @@ var PhotoSwipeUI_Default =
 		},
 		_applyNavBarGaps = function(item) {
 			var gap = item.vGap;
+      var bars = _options.barsSize;
 
-			if( _fitControlsInViewport() ) {
-				
-				var bars = _options.barsSize; 
+      if( _fitControlsInViewport() ) {
+
 				if(_options.captionEl && bars.bottom === 'auto') {
 					if(!_fakeCaptionContainer) {
 						_fakeCaptionContainer = framework.createEl('pswp__caption pswp__caption--fake');


### PR DESCRIPTION
Extended the barsSize option so that a horizontal gap can be defined like this:
options.barsSize = {top:30,bottom:30,left:30,right:30};

This way it is easy to not have the fullscreen image touch the border of the viewport, in the above example we'd have a 30px space between the image and the viewport.
