### PR TITLE
[UI] Tap/click show next image if non zoomable

### DIFF
--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -72,6 +72,7 @@ var PhotoSwipeUI_Default =
 			tapToToggleControls: true,
 
 			clickToCloseNonZoomable: true,
+			clickToShowNextNonZoomable: false,
 
 			shareButtons: [
 				{id:'facebook', label:'Share on Facebook', url:'https://www.facebook.com/sharer/sharer.php?u={{url}}'},
@@ -734,6 +735,8 @@ var PhotoSwipeUI_Default =
 				if(pswp.getZoomLevel() === 1 && pswp.getZoomLevel() <= pswp.currItem.fitRatio) {
 					if(_options.clickToCloseNonZoomable) {
 						pswp.close();
+					} else if (_options.clickToShowNextNonZoomable) {
+						pswp.next();
 					}
 				} else {
 					pswp.toggleDesktopZoom(e.detail.releasePoint);


### PR DESCRIPTION
It is false by default to keep compatibility. It is anyway overwritten by `clickToCloseNonZoomable`. Documentation is missing.