### PR TITLE
Update default-skin.scss

### DIFF
--- a/src/css/default-skin/default-skin.scss
+++ b/src/css/default-skin/default-skin.scss
@@ -345,7 +345,7 @@ a.pswp__share--download {
 }
 
 .pswp__caption__center {
-	text-align: left;
+	text-align: center;
 	max-width: 420px;
 	margin: 0 auto;
 	font-size: 13px;


### PR DESCRIPTION
it may be more logic if the class pswp__caption__center align the text to center instead of left