### PR TITLE
using parseInt() to be sure the _currentItemIndex is interpreted as an…

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -776,10 +776,10 @@ var publicMethods = {
 		self.updateCurrItem();
 	},
 	next: function() {
-		self.goTo( _currentItemIndex + 1);
+		self.goTo( parseInt(_currentItemIndex) + 1);
 	},
 	prev: function() {
-		self.goTo( _currentItemIndex - 1);
+		self.goTo( parseInt(_currentItemIndex) - 1);
 	},
 
 	// update current zoom/pan objects


### PR DESCRIPTION
… integer and the increment and decrements are numbers and not string

In my use case the _currentItemIndex was used as a string and so the + 1 leads to 51 and not 6.
With using parseInt() this behaviuor is is prevented