### PR TITLE
Fix #1390 :  'TypeError Cannot read property 'updateScrollOffset' of …

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -719,7 +719,7 @@ var publicMethods = {
 
 		_stopAllAnimations();
 
-		_listeners = null;
+		_listeners = {};
 	},
 
 	/**


### PR DESCRIPTION
 Sometimes when image onLoad is not finished yet, and the user closes photoswipe, the shout('destroy') is called, but then after image onload finished it gives this error: TypeError Cannot read property 'updateScrollOffset' of null'. 

Setting listeners to an empty object (What is also the initial value of _listeners) solves this problem.