### PR TITLE
When the image loaded error,it should not set image size.

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -155,7 +155,7 @@ var _isOpen,
 		styleObj[_transformKey] = _translatePrefix + x + 'px, ' + y + 'px' + _translateSufix + ' scale(' + zoom + ')';
 	},
 	_applyCurrentZoomPan = function( allowRenderResolution ) {
-		if(_currZoomElementStyle) {
+		if(_currZoomElementStyle && !self.currItem.loadError) {
 
 			if(allowRenderResolution) {
 				if(_currZoomLevel > self.currItem.fitRatio) {


### PR DESCRIPTION
when the image loaded error, zoom it, the position of the error msg element will be changed.