### PR TITLE
Fix #1608: Overlapped Div Gets Clicked When Closing Pswp From UI Toolbar

### DIFF
--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -457,7 +457,9 @@ var PhotoSwipeUI_Default =
 		{ 
 			name: 'button--close', 
 			option: 'closeEl',
-			onTap: pswp.close
+			onTap: function() {
+				setTimeout(pswp.close,10);
+			}
 		},
 		{ 
 			name: 'button--arrow--left', 

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -458,7 +458,7 @@ var PhotoSwipeUI_Default =
 			name: 'button--close', 
 			option: 'closeEl',
 			onTap: function() {
-				setTimeout(pswp.close,10);
+				setTimeout(pswp.close);
 			}
 		},
 		{ 


### PR DESCRIPTION
Closing photoswipe too fast causes overlapped div gets clicked! To prevent this added 10 ms delay before closing pswp.

Fixes: https://github.com/dimsemenov/PhotoSwipe/issues/1608
