### PR TITLE
Fix missing type="button" in doc

### DIFF
--- a/website/documentation/getting-started.md
+++ b/website/documentation/getting-started.md
@@ -101,13 +101,13 @@ You can add HTML code dynamically via JS (directly before the initialization), o
 				
 				<div class="pswp__counter"></div>
 
-				<button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+				<button type="button" class="pswp__button pswp__button--close" title="Close (Esc)"></button>
 
-				<button class="pswp__button pswp__button--share" title="Share"></button>
+				<button type="button" class="pswp__button pswp__button--share" title="Share"></button>
 
-				<button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+				<button type="button" class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
 
-				<button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+				<button type="button" class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
 
 				<!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
 				<!-- element will get class pswp__preloader--active when preloader is running -->
@@ -124,10 +124,10 @@ You can add HTML code dynamically via JS (directly before the initialization), o
 				<div class="pswp__share-tooltip"></div> 
 	        </div>
 
-			<button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+			<button type="button" class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
 			</button>
 			
-			<button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+			<button type="button" class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
 			</button>
 
 			<div class="pswp__caption">


### PR DESCRIPTION
If you put photoswipe html boilerplate to a `<form>` tag, these button fire submit (it is unexpected behavior).

Note that I'm using photoswipe with Vue, and child (photoswipe integrated) component does not know whether parent element is a form or not.