### PR TITLE
Adding `type` attribute to `button` tags to avoid form submitting

### DIFF
--- a/website/documentation/getting-started.md
+++ b/website/documentation/getting-started.md
@@ -101,13 +101,13 @@ You can add HTML code dynamically via JS (directly before the initialization), o
 				
 				<div class="pswp__counter"></div>
 
-				<button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+				<button type="button" class="pswp__button pswp__button--close" title="Close (Esc)"></button>
 
-				<button class="pswp__button pswp__button--share" title="Share"></button>
+				<button type="button" class="pswp__button pswp__button--share" title="Share"></button>
 
-				<button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+				<button type="button" class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
 
-				<button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+				<button type="button" class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
 
 				<!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
 				<!-- element will get class pswp__preloader--active when preloader is running -->
@@ -124,10 +124,10 @@ You can add HTML code dynamically via JS (directly before the initialization), o
 				<div class="pswp__share-tooltip"></div> 
 	        </div>
 
-			<button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+			<button type="button" class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
 			</button>
 			
-			<button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+			<button type="button" class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
 			</button>
 
 			<div class="pswp__caption">

--- a/website/index.html
+++ b/website/index.html
@@ -530,13 +530,13 @@ buildtool: false
 
 				<div class="pswp__counter"></div>
 
-				<button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+				<button type="button" class="pswp__button pswp__button--close" title="Close (Esc)"></button>
 
-				<button class="pswp__button pswp__button--share" title="Share"></button>
+				<button type="button" class="pswp__button pswp__button--share" title="Share"></button>
 
-				<button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+				<button type="button" class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
 
-				<button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+				<button type="button" class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
 
 				<div class="pswp__preloader">
 					<div class="pswp__preloader__icn">
@@ -559,8 +559,8 @@ buildtool: false
 	            </div>
 	        </div>
 
-            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button>
-            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button>
+            <button type="button" class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)"></button>
+            <button type="button" class="pswp__button pswp__button--arrow--right" title="Next (arrow right)"></button>
             <div class="pswp__caption">
               <div class="pswp__caption__center">
               </div>


### PR DESCRIPTION
Hi,
When adding **PhotoSwipe (.pswp) element to DOM** inside a block, it may some time create a conflict when the block is a form.
We have added the html attribute `type="button"` to all buttons inside **PhotoSwipe (.pswp) element** to avoid that conflict. 