### PR TITLE
suppressing incorrect mousedown in case of firefox android where PointerEvent not enabled by default

### DIFF
--- a/src/js/gestures.js
+++ b/src/js/gestures.js
@@ -299,7 +299,7 @@ var _gestureStartTime,
 		// 
 		// http://www.quirksmode.org/js/events_properties.html
 		// https://developer.mozilla.org/en-US/docs/Web/API/event.button
-		if(e.type === 'mousedown' && e.button > 0  ) {
+		if(e.type === 'mousedown' && (e.button > 0 || e.buttons === 0)) {
 			return;
 		}
 


### PR DESCRIPTION
This PR will fix an issue on Firefox browser on Android

While clicking on the share icon on the top of the individual photos, it opens up a menu with share item links like "Share on Facebook", "Tweet" etc

When we click on any of this share item link,

The **touchstart** as well as **mousedown** events both are fired, due to which **onDragStart** event is fired twice and gives rise to the bug where the image zooms in and out even when its not been touched but the share items are clicked. Please check the capture video below,

https://drive.google.com/file/d/0B3An_5LN4cT8d3pQNEN6WWFsZDRBaC1tam5helJXUVlUaUtz/view?usp=sharing

Now again the root cause for this is that **PointerEvent** constructor support is not enabled on Firefox by default. More on this here, https://caniuse.com/#feat=pointer

To fix this we need to ignore the invalid **mousedown** event as we are on touch device and only **touchstart** event should be fired.

Also the event object for mousedown has buttons: 0 which means the the button is uninitialized which makes sense as this was a touch event. 

More on that here. [MouseEvent buttons](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons) `0: No button or un-initialized`