### PR TITLE
Pass custom window object via PhotoSwipe options parameter.

### DIFF
--- a/dist/photoswipe-ui-default.js
+++ b/dist/photoswipe-ui-default.js
@@ -23,6 +23,8 @@
 
 var PhotoSwipeUI_Default =
  function(pswp, framework) {
+	var window = pswp.options.window || window;
+	var document = window.document;
 
 	var ui = this;
 	var _overlayUIUpdated = false,

--- a/dist/photoswipe.js
+++ b/dist/photoswipe.js
@@ -13,6 +13,8 @@
 
 	'use strict';
 	var PhotoSwipe = function(template, UiClass, items, options){
+		var window = options.window || window;
+		var document = window.document;
 
 /*>>framework-bridge*/
 /**

--- a/src/js/framework-bridge.js
+++ b/src/js/framework-bridge.js
@@ -1,3 +1,6 @@
+var window = options.window || window;
+var document = window.document;
+
 /**
  *
  * Set of generic functions used by gallery.

--- a/src/js/ui/photoswipe-ui-default.js
+++ b/src/js/ui/photoswipe-ui-default.js
@@ -20,6 +20,8 @@
 
 var PhotoSwipeUI_Default =
  function(pswp, framework) {
+	var window = pswp.options.window || window;
+	var document = window.document;
 
 	var ui = this;
 	var _overlayUIUpdated = false,


### PR DESCRIPTION
Add in ability to pass custom window object via options parameter. The 'window' and 'document' are reassigned to variables of the same name within the scope of PhotoSwipe to ensure the passed window and associated document are used instead. The global window and associated document are used as fallbacks in the case where a custom window object is not passed via the options parameter.