### PR TITLE
Update gruntfile.js and packages.json because of changes to grunt-sass.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,8 @@ module.exports = function(grunt) {
 
   'use strict';
 
+  const sass = require('node-sass');
+
   var jekyllConfig = "isLocal : false \r\n"+
       "permalink: /:title/ \r\n"+
       "exclude: ['.json', '.rvmrc', '.rbenv-version', 'README.md', 'Rakefile'," +
@@ -42,7 +44,11 @@ module.exports = function(grunt) {
       files: ['dist']
     },
     
-    sass: {                            
+    sass: {        
+      options: { 
+        implementation: sass, 
+        sourceMap: true 
+      },                    
       dist: {                      
         files: {      
           'dist/photoswipe.css': 'src/css/main.scss',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
       "auto: true \r\n"+
       "pswpversion: <%= pkg.version %> \r\n"+
       "siteversion: 1.0.4 \r\n"+
-      "markdown: redcarpet \r\n"+
+      "markdown: kramdown \r\n"+
       "kramdown: \r\n"+
       "  input: GFM \r\n";
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "grunt-contrib-uglify": "~4.0.0",
     "grunt-contrib-watch": "~1.1.0",
     "grunt-jekyll": "~1.0.0",
-    "grunt-sass": "^3.0.2",
-    "grunt-svgmin": "^5.0.0"
+    "grunt-sass": "^3.1.0",
+    "grunt-svgmin": "^5.0.0",
+    "node-sass": "^4.13.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When attempting to run grunt after installation according to the instructions, the terminal shows:
    Running "sass:dist" (sass) task
    Fatal error: The implementation option must be passed to the Sass task
That led me to https://github.com/them-es/themes-starter-bootstrap/issues/1 and then https://www.npmjs.com/package/grunt-sass/v/3.0.0

Adding just the options block in the gruntfile but failing to update packages leads to this error in the terminal:
    Loading "Gruntfile.js" tasks...ERROR
    >> Error: Cannot find module 'node-sass'
so I first added
   "node-sass": "*"
but after running
    npm install --save-dev node-sass grunt-sass
the line was changed to
    "node-sass": "^4.13.1"

Initially I had an error related to the jekyllConfig section of gruntfile.js indicating that redcarpet was not installed so I changed line 24 to
    "markdown: kramdown \r\n"+
but now it seems to work just fine with the original setting.