### PR TITLE
Init from DOM – click handler defers to Anchor elements

### DIFF
--- a/website/documentation/getting-started.md
+++ b/website/documentation/getting-started.md
@@ -344,9 +344,15 @@ var initPhotoSwipeFromDOM = function(gallerySelector) {
 	// triggers when user clicks on thumbnail
 	var onThumbnailsClick = function(e) {
 		e = e || window.event;
-		e.preventDefault ? e.preventDefault() : e.returnValue = false;
-
 		var eTarget = e.target || e.srcElement;
+
+		// if it's a link that has been clicked, defer to this default action
+		if (eTarget.tagName === 'A') {
+			e.stopPropagation();
+			return
+		}
+		// otherwise, prevent that default action and proceed to action PhotoSwipe
+		e.preventDefault ? e.preventDefault() : e.returnValue = false;
 
 		// find root element of slide
 		var clickedListItem = closest(eTarget, function(el) {


### PR DESCRIPTION
The supplied javascript in `How to build an array of slides from a list of links` will action opening PhotoSwipe even if it was a link that was clicked (e.g. within `<figcaption>` text). This PR contains a small modification to that code so that PhotoSwipe defers to any anchor tag's action instead.