### PR TITLE
docs: Fix simple typo, untill -> until

### DIFF
--- a/dist/photoswipe.js
+++ b/dist/photoswipe.js
@@ -943,7 +943,7 @@ var publicMethods = {
 			if(_options.focus) {
 				// focus causes layout, 
 				// which causes lag during the animation, 
-				// that's why we delay it untill the initial zoom transition ends
+				// that's why we delay it until the initial zoom transition ends
 				template.focus();
 			}
 			 

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -645,7 +645,7 @@ var publicMethods = {
 			if(_options.focus) {
 				// focus causes layout, 
 				// which causes lag during the animation, 
-				// that's why we delay it untill the initial zoom transition ends
+				// that's why we delay it until the initial zoom transition ends
 				template.focus();
 			}
 			 


### PR DESCRIPTION
There is a small typo in dist/photoswipe.js, src/js/core.js.

Should read `until` rather than `untill`.

