### PR TITLE
fix: errorMsg may cause XSS attack

### DIFF
--- a/src/js/items-controller.js
+++ b/src/js/items-controller.js
@@ -179,8 +179,12 @@ var _getItemAt,
 			if(cleanUp) {
 				item.container.innerHTML = '';
 			}
-
-			item.container.innerHTML = _options.errorMsg.replace('%url%',  item.src );
+			const lt = /</g, 
+						gt = />/g, 
+						ap = /'/g, 
+						ic = /"/g;
+			const safeSrc = item.src.toString().replace(lt, "&lt;").replace(gt, "&gt;").replace(ap, "&#39;").replace(ic, "&#34;");
+			item.container.innerHTML = _options.errorMsg.replace('%url%', safeSrc);
 			return true;
 			
 		}


### PR DESCRIPTION
Hi, guy, I found a bug which will cause XSS attack, in `errorMSg`, you use `innerHTML` to replace `%url`, but origin image src url maybe an unsafe url, like this `https://example.com/"/>"<script>alert("1")</script>"<a `. So, must escape origin image url, replace `<` `>` `'` or `"` .

This bug not only in default error message, but also in custom error.
![image](https://user-images.githubusercontent.com/41265413/116071176-2931e700-a6c0-11eb-88b2-6370e9359c6d.png)
