### PR TITLE
Document how to ignore click-or-tap

### DIFF
--- a/docs/click-and-tap-actions.md
+++ b/docs/click-and-tap-actions.md
@@ -23,6 +23,7 @@ List of options:
 ```js
 imageClickAction: (releasePoint, e) => {}
 ```
+- Any other value, for example `'none'`, will cause the click or tap to be ignored.
 
 
 ## Click on image moves to the next slide


### PR DESCRIPTION
Document that any action other than those specified will cause the click or tap event to be silently ignored.