### PR TITLE
Fix #1754: The code after build has errors.

### DIFF
--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -73,13 +73,13 @@ export function clamp(val, min, max) {
  */
 export function toTransformString(x, y, scale) {
   let propValue = 'translate3d('
-                      + x + 'px,' + (y || 0) + 'px'
-                      + ',0)';
+    + x + 'px,' + (y || 0) + 'px'
+    + ',0)';
 
   if (scale !== undefined) {
     propValue += ' scale3d('
-                      + scale + ',' + scale
-                      + ',1)';
+      + scale + ',' + scale
+      + ',1)';
   }
 
   return propValue;
@@ -121,7 +121,7 @@ export function removeTransitionStyle(el) {
 }
 
 export function decodeImage(img) {
-  if ('decode' in new Image()) {
+  if ('decode' in img) {
     return img.decode();
   }
 

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -120,25 +120,13 @@ export function removeTransitionStyle(el) {
   setTransitionStyle(el);
 }
 
-const supportsImageDecode = () => {
-  return 'decode' in new Image();
-};
-
-export function isImageDecoded(img) {
-  if (supportsImageDecode) {
-    return img.decoded;
-  }
-
-  return img.complete;
-}
-
 export function decodeImage(img) {
-  if (isImageDecoded(img)) {
-    return Promise.resolve(img);
+  if ('decode' in new Image()) {
+    return img.decode();
   }
 
-  if (supportsImageDecode) {
-    return img.decode();
+  if (img.complete) {
+    return Promise.resolve(img);
   }
 
   return new Promise((resolve, reject) => {

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -120,7 +120,9 @@ export function removeTransitionStyle(el) {
   setTransitionStyle(el);
 }
 
-const supportsImageDecode = ('decode' in new Image());
+const supportsImageDecode = () => {
+  return 'decode' in new Image();
+};
 
 export function isImageDecoded(img) {
   if (supportsImageDecode) {


### PR DESCRIPTION
closed #1754 

After modification, the error code `('decode' in new Image());` will no longer appear after `photoswipe-lightbox.esm.js` build.

![image](https://user-images.githubusercontent.com/44798353/120772762-3958a400-c553-11eb-97df-d9541271c0d8.png)