### PR TITLE
Fix #1757: Null pointer error when opening custom "HTML slide"

### DIFF
--- a/src/js/opener.js
+++ b/src/js/opener.js
@@ -207,8 +207,10 @@ class Opener {
     this.pswp.template.classList[this.isOpening ? 'add' : 'remove']('pswp--ui-visible');
 
     if (this.isOpening) {
-      // unhide the placeholder
-      this._placeholder.style.opacity = 1;
+      if (this._placeholder) {
+        // unhide the placeholder
+        this._placeholder.style.opacity = 1;
+      }
       this._animateToOpenState();
     } else if (this.isClosing) {
       this._animateToClosedState();


### PR DESCRIPTION
When opening "HTML slide", `this._placeholder` is `undefined`.

example:

[https://codepen.io/zsdycs/pen/rNyKLRK](https://codepen.io/zsdycs/pen/rNyKLRK)

When `lightbox.loadAndOpen(0);` is changed to `lightbox.loadAndOpen(1);`, you can see the error message on the console.
