### PR TITLE
Added support for pswpModule import without absolute path

### DIFF
--- a/dist/photoswipe-lightbox.esm.js
+++ b/dist/photoswipe-lightbox.esm.js
@@ -227,19 +227,19 @@ function lazyLoadSlide(index, instance) {
 
 function dynamicImportModule(module) {
   // TODO: polyfill import?
-  return import(module);
+  return typeof module === 'string' ? import(module) : module;
 }
 
 function dynamicImportPlugin(pluginKey, pluginItem) {
   return new Promise((resolve) => {
-    if (typeof pluginItem === 'string') {
+    if(module != null){
       dynamicImportModule(pluginItem).then((module) => {
         resolve({
           pluginKey,
-          moduleClass: module.default
+          moduleClass: typeof module === 'string' ? module.default : module
         });
       }).catch(resolve);
-    } else {
+    } else{
       resolve();
     }
   });
@@ -689,10 +689,10 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     }
 
     // Pass data to PhotoSwipe and open init
-    const pswp = new module.default( // eslint-disable-line
-      null,
-      this.options
-    );
+    const pswp = typeof module === "object" 
+        ? new module.default(null, this.options) // eslint-disable-line
+        : new module(null, this.options);
+
     pswp.pluginClasses = this._pluginClasses;
 
     this.pswp = pswp;

--- a/dist/photoswipe-lightbox.esm.js
+++ b/dist/photoswipe-lightbox.esm.js
@@ -227,19 +227,19 @@ function lazyLoadSlide(index, instance) {
 
 function dynamicImportModule(module) {
   // TODO: polyfill import?
-  return typeof module === 'string' ? import(module) : module;
+  return import(module);
 }
 
 function dynamicImportPlugin(pluginKey, pluginItem) {
   return new Promise((resolve) => {
-    if(module != null){
+    if (typeof pluginItem === 'string') {
       dynamicImportModule(pluginItem).then((module) => {
         resolve({
           pluginKey,
-          moduleClass: typeof module === 'string' ? module.default : module
+          moduleClass: module.default
         });
       }).catch(resolve);
-    } else{
+    } else {
       resolve();
     }
   });
@@ -689,10 +689,10 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     }
 
     // Pass data to PhotoSwipe and open init
-    const pswp = typeof module === "object" 
-        ? new module.default(null, this.options) // eslint-disable-line
-        : new module(null, this.options);
-
+    const pswp = new module.default( // eslint-disable-line
+      null,
+      this.options
+    );
     pswp.pluginClasses = this._pluginClasses;
 
     this.pswp = pswp;

--- a/src/js/lightbox/dynamic-import.js
+++ b/src/js/lightbox/dynamic-import.js
@@ -1,18 +1,18 @@
 export function dynamicImportModule(module) {
   // TODO: polyfill import?
-  return import(module);
+  return typeof module === 'string' ? import(module) : module;
 }
 
 export function dynamicImportPlugin(pluginKey, pluginItem) {
   return new Promise((resolve) => {
-    if (typeof pluginItem === 'string') {
+    if(typeof pluginItem === 'string' || typeof pluginItem === 'object'){
       dynamicImportModule(pluginItem).then((module) => {
         resolve({
           pluginKey,
-          moduleClass: module.default
+          moduleClass: typeof module === 'string' ? module.default : module
         });
       }).catch(resolve);
-    } else {
+    } else{
       resolve();
     }
   });

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -207,10 +207,10 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     }
 
     // Pass data to PhotoSwipe and open init
-    const pswp = new module.default( // eslint-disable-line
-      null,
-      this.options
-    );
+    const pswp = typeof module === "object" 
+        ? new module.default(null, this.options) // eslint-disable-line
+        : new module(null, this.options);
+
     pswp.pluginClasses = this._pluginClasses;
 
     this.pswp = pswp;


### PR DESCRIPTION
This pull request gives the ability for users to import the pswpModule script without an absolute path; it's extremely useful when PhotoSwipe is saved as a node module. However, it still allows for the absolute path to be given instead...

Example:

```
import PhotoSwipeLightbox from 'photoswipe/dist/photoswipe-lightbox.esm.js';
import {default as PhotoMain} from 'photoswipe/dist/photoswipe.esm.js';
	
import 'photoswipe/dist/photoswipe.css';

let lightbox;

onMount(() => {
        lightbox = new PhotoSwipeLightbox({
	        gallerySelector: '#gallery--simple',
		childSelector: 'a',
		pswpModule: PhotoMain
	});
        lightbox.init();
});
```