### PR TITLE
Allow to set different paddings per slide

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -38,7 +38,7 @@ Object, `{ top: 0, bottom: 0, left: 0, right: 0 }`. Slide area padding (in pixel
 Function, should return padding object. Overrides `padding` option if defined. For example:
 
 ```
-paddingFn: (viewportSize) => {
+paddingFn: (viewportSize, itemData) => {
   return {
     top: 0,
     bottom: viewportSize.x < 600 ? 0 : 200,

--- a/src/js/slide/loader.js
+++ b/src/js/slide/loader.js
@@ -43,7 +43,7 @@ export function lazyLoadData(itemData, instance, index) {
   // We need to know dimensions of the image to preload it,
   // as it might use srcset and we need to define sizes
   const viewportSize = instance.viewportSize || getViewportSize(options);
-  const panAreaSize = getPanAreaSize(options, viewportSize);
+  const panAreaSize = getPanAreaSize(options, viewportSize, itemData);
 
   const zoomLevel = new ZoomLevel(options, itemData, -1);
   zoomLevel.update(content.width, content.height, panAreaSize);

--- a/src/js/slide/pan-bounds.js
+++ b/src/js/slide/pan-bounds.js
@@ -34,10 +34,10 @@ class PanBounds {
 
   // _calculateItemBoundsForAxis
   _updateAxis(axis) {
-    const { pswp } = this.slide;
+    const { pswp, data } = this.slide;
     const elSize = this.slide[axis === 'x' ? 'width' : 'height'] * this.currZoomLevel;
     const paddingProp = axis === 'x' ? 'left' : 'top';
-    const padding = parsePaddingOption(paddingProp, pswp.options, pswp.viewportSize);
+    const padding = parsePaddingOption(paddingProp, pswp.options, pswp.viewportSize, data);
 
     const panAreaSize = this.slide.panAreaSize[axis];
 

--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -492,7 +492,7 @@ class Slide {
 
     equalizePoints(
       this.panAreaSize,
-      getPanAreaSize(pswp.options, pswp.viewportSize, pswp)
+      getPanAreaSize(pswp.options, pswp.viewportSize, this.data/*, pswp*/)
     );
 
     this.zoomLevels.update(this.width, this.height, this.panAreaSize);

--- a/src/js/util/viewport-size.js
+++ b/src/js/util/viewport-size.js
@@ -30,7 +30,7 @@ export function getViewportSize(options, pswp) {
  * }
  *
  * // A function that returns the object
- * paddingFn: (viewportSize) => {
+ * paddingFn: (viewportSize, itemData) => {
  *  return {
  *    top: 0,
  *    bottom: 0,
@@ -48,13 +48,14 @@ export function getViewportSize(options, pswp) {
  * @param {String} prop 'left', 'top', 'bottom', 'right'
  * @param {Object} options PhotoSwipe options
  * @param {Object} viewportSize PhotoSwipe viewport size, for example: { x:800, y:600 }
+ * @param {Object} itemData Slide data
  * @returns {Number}
  */
-export function parsePaddingOption(prop, options, viewportSize) {
+export function parsePaddingOption(prop, options, viewportSize, itemData) {
   let paddingValue;
 
   if (options.paddingFn) {
-    paddingValue = options.paddingFn(viewportSize)[prop];
+    paddingValue = options.paddingFn(viewportSize, itemData)[prop];
   } else if (options.padding) {
     paddingValue = options.padding[prop];
   } else {
@@ -68,13 +69,13 @@ export function parsePaddingOption(prop, options, viewportSize) {
 }
 
 
-export function getPanAreaSize(options, viewportSize/*, pswp*/) {
+export function getPanAreaSize(options, viewportSize, itemData/*, pswp*/) {
   return {
     x: viewportSize.x
-      - parsePaddingOption('left', options, viewportSize)
-      - parsePaddingOption('right', options, viewportSize),
+      - parsePaddingOption('left', options, viewportSize, itemData)
+      - parsePaddingOption('right', options, viewportSize, itemData),
     y: viewportSize.y
-      - parsePaddingOption('top', options, viewportSize)
-      - parsePaddingOption('bottom', options, viewportSize)
+      - parsePaddingOption('top', options, viewportSize, itemData)
+      - parsePaddingOption('bottom', options, viewportSize, itemData)
   };
 }


### PR DESCRIPTION
This PR adds itemData (Slide data) in paddingFn, it allows to know which slide is concerned in the callback so we can set different paddings per slide. In my case, I have some images without background and bordeless, I need to set specific padding for those images.

I can set up a demo page if needed, it's working fine locally. Thanks :)