### PR TITLE
Added object-position property support.

### DIFF
--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -150,6 +150,7 @@ class PhotoSwipeBase extends Eventable {
 
       if (linkEl.dataset.pswpCropped || linkEl.dataset.cropped) {
         itemData.thumbCropped = true;
+        itemData.thumbCroppedPosition = linkEl.dataset.croppedPosition || 'center center';
       }
     }
 

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -150,7 +150,11 @@ class PhotoSwipeBase extends Eventable {
 
       if (linkEl.dataset.pswpCropped || linkEl.dataset.cropped) {
         itemData.thumbCropped = true;
-        itemData.thumbCroppedPosition = linkEl.dataset.croppedPosition || 'center center';
+        itemData.thumbCroppedPosition = '50% 50%';
+
+        if (thumbnailEl) {
+          itemData.thumbCroppedPosition = getComputedStyle(thumbnailEl).getPropertyValue('object-position')
+        }
       }
     }
 

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -150,11 +150,9 @@ class PhotoSwipeBase extends Eventable {
 
       if (linkEl.dataset.pswpCropped || linkEl.dataset.cropped) {
         itemData.thumbCropped = true;
-        itemData.thumbCroppedPosition = '50% 50%';
-
-        if (thumbnailEl) {
-          itemData.thumbCroppedPosition = getComputedStyle(thumbnailEl).getPropertyValue('object-position')
-        }
+        itemData.thumbCroppedPosition = thumbnailEl
+          ? getComputedStyle(thumbnailEl).getPropertyValue('object-position')
+          : '50% 50%';
       }
     }
 

--- a/src/js/slide/get-thumb-bounds.js
+++ b/src/js/slide/get-thumb-bounds.js
@@ -44,7 +44,7 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight, position) {
 function getCroppedBoundsOffset(position, imageSize, thumbSize, zoomLevel) {
   const float = parseFloat(position);
 
-  if (position.indexOf('%')) {
+  if (position.indexOf('%') > 0) {
     return (thumbSize - imageSize * zoomLevel) * float / 100;
   }
 

--- a/src/js/slide/get-thumb-bounds.js
+++ b/src/js/slide/get-thumb-bounds.js
@@ -44,11 +44,9 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight, position) {
 function getCroppedBoundsOffset(position, imageSize, thumbSize, zoomLevel) {
   const float = parseFloat(position);
 
-  if (position.indexOf('%') > 0) {
-    return (thumbSize - imageSize * zoomLevel) * float / 100;
-  }
-
-  return float;
+  return position.indexOf('%') > 0
+    ? (thumbSize - imageSize * zoomLevel) * float / 100
+    : float;
 }
 
 /**

--- a/src/js/slide/get-thumb-bounds.js
+++ b/src/js/slide/get-thumb-bounds.js
@@ -7,7 +7,7 @@ function getBoundsByElement(el) {
   };
 }
 
-function getCroppedBoundsByElement(el, imageWidth, imageHeight) {
+function getCroppedBoundsByElement(el, imageWidth, imageHeight, position) {
   const thumbAreaRect = el.getBoundingClientRect();
 
   // fill image into the area
@@ -15,9 +15,10 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight) {
   const hRatio = thumbAreaRect.width / imageWidth;
   const vRatio = thumbAreaRect.height / imageHeight;
   const fillZoomLevel = hRatio > vRatio ? hRatio : vRatio;
+  const [positionX, positionY = 'center'] = position.split(' ');
 
-  const offsetX = (thumbAreaRect.width - imageWidth * fillZoomLevel) / 2;
-  const offsetY = (thumbAreaRect.height - imageHeight * fillZoomLevel) / 2;
+  const offsetX = getCroppedBoundsOffset(positionX, imageWidth, thumbAreaRect.width, fillZoomLevel);
+  const offsetY = getCroppedBoundsOffset(positionY, imageHeight, thumbAreaRect.height, fillZoomLevel);
 
   // Coordinates of the image,
   // as if it was not cropped,
@@ -38,6 +39,21 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight) {
   };
 
   return bounds;
+}
+
+function getCroppedBoundsOffset(position, imageSize, thumbSize, zoomLevel) {
+  switch (position) {
+    case 'top':
+    case 'left':
+      return 0;
+    case 'center':
+      return (thumbSize - imageSize * zoomLevel) / 2;
+    case 'bottom':
+    case 'right':
+      return thumbSize;
+    default:
+      return position;
+  }
 }
 
 /**
@@ -79,7 +95,8 @@ export function getThumbBounds(index, itemData, instance) {
       thumbBounds = getCroppedBoundsByElement(
         thumbnail,
         itemData.w,
-        itemData.h
+        itemData.h,
+        itemData.thumbCroppedPosition
       );
     }
   }

--- a/src/js/slide/get-thumb-bounds.js
+++ b/src/js/slide/get-thumb-bounds.js
@@ -15,7 +15,7 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight, position) {
   const hRatio = thumbAreaRect.width / imageWidth;
   const vRatio = thumbAreaRect.height / imageHeight;
   const fillZoomLevel = hRatio > vRatio ? hRatio : vRatio;
-  const [positionX, positionY = 'center'] = position.split(' ');
+  const [positionX, positionY] = position.split(' ');
 
   const offsetX = getCroppedBoundsOffset(positionX, imageWidth, thumbAreaRect.width, fillZoomLevel);
   const offsetY = getCroppedBoundsOffset(positionY, imageHeight, thumbAreaRect.height, fillZoomLevel);
@@ -42,18 +42,13 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight, position) {
 }
 
 function getCroppedBoundsOffset(position, imageSize, thumbSize, zoomLevel) {
-  switch (position) {
-    case 'top':
-    case 'left':
-      return 0;
-    case 'center':
-      return (thumbSize - imageSize * zoomLevel) / 2;
-    case 'bottom':
-    case 'right':
-      return thumbSize;
-    default:
-      return position;
+  const float = parseFloat(position);
+
+  if (position.indexOf('%')) {
+    return (thumbSize - imageSize * zoomLevel) * float / 100;
   }
+
+  return float;
 }
 
 /**


### PR DESCRIPTION
I was trying to add a basic [object-position support](https://github.com/dimsemenov/PhotoSwipe/issues/1842).

This approach ~~requires to use additional data attribute `data-cropped-position`~~:

```html
<a ...
  data-cropped="true">
  <img ../>
</a>
```

```css
img {
  object-fit: cover;
  object-position: center top;
}
```

Demo link: https://breezefront.com/screenshots