### PR TITLE
Fix download icon path in docs example

### DIFF
--- a/docs/adding-ui-elements.md
+++ b/docs/adding-ui-elements.md
@@ -118,12 +118,12 @@ lightbox.on('uiRegister', function() {
     // SVG with outline
     html: {
       isCustomSVG: true,
-      inner: '<path d="M20.5 14.3 17.1 18V10h-2.2v7.9l-3.4-3.6L10 16l6 6.1 6-6.1-1.5-1.6ZM23 23H9v2h14" id="pswp__icn-download"/>',
+      inner: '<path d="M20.5 14.3 17.1 18V10h-2.2v7.9l-3.4-3.6L10 16l6 6.1 6-6.1ZM23 23H9v2h14Z" id="pswp__icn-download"/>',
       outlineID: 'pswp__icn-download'
     },
 
     // Or provide full svg:
-    // html: '<svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true" class="pswp__icn"><path d="M20.5 14.3 17.1 18V10h-2.2v7.9l-3.4-3.6L10 16l6 6.1 6-6.1-1.5-1.6ZM23 23H9v2h14" /></svg>',
+    // html: '<svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true" class="pswp__icn"><path d="M20.5 14.3 17.1 18V10h-2.2v7.9l-3.4-3.6L10 16l6 6.1 6-6.1ZM23 23H9v2h14Z" /></svg>',
 
     // Or provide any other markup:
     // html: '<i class="fa-solid fa-download"></i>' 


### PR DESCRIPTION
Hi!

### Problem

I found visual bug (svg path inaccuracy) during repeating of ["Adding download button" example](https://photoswipe.com/adding-ui-elements/#adding-download-button).

<img width="59" alt="Снимок экрана 2022-04-11 в 12 36 16" src="https://user-images.githubusercontent.com/37641303/162657454-154d1ea2-84b6-49f8-b9f4-57ea2d9de0a0.png">

When download icon is above the light background, we can see, that outline is not correct (this is because of bug in svg path).

### Steps to reproduce

1. Open https://photoswipe.com/adding-ui-elements/#adding-download-button
2. Click on slide thumbnail
3. Resize the screen, so download icon is above the light image

