### PR TITLE
Implement type definitions generation via JSDoc comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+!.*.js
+.eslintrc.js
+*.d.ts
+*.ts

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
         }
     ],
     "rules": {
+        "max-len": ["error", { "code": 100, "comments": 120 }],
         "comma-dangle": "off",
         "no-param-reassign": 0,
         "import/extensions": 0,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,10 @@
     "parser": "@babel/eslint-parser",
     "parserOptions": {
         "sourceType": "module",
-        "requireConfigFile": false
+        "requireConfigFile": false,
+        "babelOptions": {
+          "plugins": ["@babel/plugin-syntax-class-properties"]
+        }
     },
     "overrides": [
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
         }
     ],
     "rules": {
-        "max-len": ["error", { "code": 100, "comments": 120 }],
+        "max-len": ["error", { "code": 100, "comments": 140 }],
         "comma-dangle": "off",
         "no-param-reassign": 0,
         "import/extensions": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,3 @@ website/dist/
 /.idea
 .node-version
 .sass-cache/
-
-types/

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ website/dist/
 /.idea
 .node-version
 .sass-cache/
+
+types/

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,2 +1,0 @@
-declare type Methods<T> = {[M in keyof T]: T[M] extends (...a: any) => any ? M : never}[keyof T]
-declare type AddPostfix<T, P> = `${T}${P}`

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,1 +1,2 @@
 declare type Methods<T> = {[M in keyof T]: T[M] extends (...a: any) => any ? M : never}[keyof T]
+declare type AddPostfix<T, P> = `${T}${P}`

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,1 @@
+declare type Methods<T> = {[M in keyof T]: T[M] extends (...a: any) => any ? M : never}[keyof T]

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,7 @@
+export {}
+
+declare global {
+  interface Window {
+      pswp?: import('./src/js/photoswipe').default;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "eslint-plugin-import": "^2.22.1",
         "rollup": "^2.46.0",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-terser": "^7.0.2"
+        "rollup-plugin-terser": "^7.0.2",
+        "typescript": "^4.6.4"
       },
       "engines": {
         "node": ">= 0.12.0"
@@ -4073,6 +4074,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -7483,6 +7497,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,4313 @@
 {
   "name": "photoswipe",
   "version": "5.2.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "photoswipe",
+      "version": "5.2.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.13.16",
+        "@babel/eslint-parser": "^7.13.14",
+        "chokidar-cli": "^3.0.0",
+        "concurrently": "^6.0.2",
+        "copyfiles": "^2.4.1",
+        "eslint": "^7.25.0",
+        "eslint-config-airbnb-base": "^13.2.0",
+        "eslint-plugin-import": "^2.22.1",
+        "rollup": "^2.46.0",
+        "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-terser": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
+      "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==",
+      "dev": true
+    },
+    "node_modules/@babel/core": {
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+      "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.16",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-module-transforms": "^7.13.14",
+        "@babel/helpers": "^7.13.16",
+        "@babel/parser": "^7.13.16",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.15",
+        "@babel/types": "^7.13.16",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/core/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.13.14.tgz",
+      "integrity": "sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "^5.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": ">=7.5.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+      "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.16",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+      "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.13.15",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "^6.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.14"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+      "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
+        "@babel/helper-optimise-call-expression": "^7.12.13",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.13.12"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "dev": true
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+      "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.17",
+        "@babel/types": "^7.13.17"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+      "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.16",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.13.16",
+        "@babel/types": "^7.13.17",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.13.17",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+      "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.4",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.4",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
+      "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
+      "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.16.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
+      "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001214",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.719",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.71"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001319",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
+      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar-cli": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+      "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "chokidar": "index.js"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/concurrently": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.0.2.tgz",
+      "integrity": "sha512-u+1Q0dJG5BidgUTpz9CU16yoHTt/oApFDQ3mbvHwSDgMjU7aGqy0q8ZQyaZyaNxdwRKTD872Ux3Twc6//sWA+Q==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.16.1",
+        "lodash": "^4.17.21",
+        "read-pkg": "^5.2.0",
+        "rxjs": "^6.6.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "concurrently": "bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concurrently/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
+      "dev": true
+    },
+    "node_modules/contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/copyfiles/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/copyfiles/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/copyfiles/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/copyfiles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/copyfiles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/copyfiles/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/copyfiles/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/copyfiles/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/copyfiles/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/copyfiles/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/copyfiles/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/copyfiles/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/copyfiles/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/copyfiles/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.1.tgz",
+      "integrity": "sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.3.723",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.723.tgz",
+      "integrity": "sha512-L+WXyXI7c7+G1V8ANzRsPI5giiimLAUDC6Zs1ojHHPhYXb3k/iTABFmWjivEtsWrRQymjnO66/rO2ZTABGdmWg==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
+      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-airbnb-base": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+      "dev": true,
+      "dependencies": {
+        "confusing-browser-globals": "^1.0.5",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint": "^4.19.1 || ^5.3.0",
+        "eslint-plugin-import": "^2.17.2"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint/node_modules/@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/eslint/node_modules/@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
+      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-extra/node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/globby": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/json5/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "node_modules/load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/load-json-file/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+      "dev": true
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "1.1.71",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "dev": true
+    },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/noms/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/noms/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/noms/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
+      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1",
+        "has": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "has": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-type/node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.46.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.46.0.tgz",
+      "integrity": "sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/rollup-plugin-copy": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-3.4.0.tgz",
+      "integrity": "sha512-rGUmYYsYsceRJRqLVlE9FivJMxJ7X6jDlP79fmFkL8sJs7VVMSVyA2yfyL+PGyO/vJs4A87hwhgVfz61njI+uQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/fs-extra": "^8.0.1",
+        "colorette": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "10.0.1",
+        "is-plain-object": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/rollup-plugin-terser": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+      "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "jest-worker": "^26.2.1",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^5.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "dev": true
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
+      "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
+      "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
+      "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.19"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.12.13",
@@ -470,7 +4775,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -2933,6 +7239,15 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -2976,15 +7291,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,12 +28,15 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/highlight": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -70,26 +73,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
       }
     },
     "node_modules/@babel/core/node_modules/json5": {
@@ -308,10 +291,13 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -331,14 +317,17 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -376,26 +365,6 @@
         "@babel/types": "^7.12.13"
       }
     },
-    "node_modules/@babel/template/node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/template/node_modules/@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      }
-    },
     "node_modules/@babel/traverse": {
       "version": "7.13.17",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
@@ -410,26 +379,6 @@
         "@babel/types": "^7.13.17",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
       }
     },
     "node_modules/@babel/types": {
@@ -1741,31 +1690,6 @@
       "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/eslint/node_modules/@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint/node_modules/ansi-regex": {
@@ -3539,9 +3463,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.46.0.tgz",
-      "integrity": "sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==",
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.71.1.tgz",
+      "integrity": "sha512-lMZk3XfUBGjrrZQpvPSoXcZSfKcJ2Bgn+Z0L1MoW2V8Wh7BVM+LOBJTPo16yul2MwL59cXedzW1ruq3rCjSRgw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3550,7 +3474,7 @@
         "node": ">=10.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-copy": {
@@ -4346,12 +4270,12 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.12.13"
+        "@babel/highlight": "^7.16.7"
       }
     },
     "@babel/compat-data": {
@@ -4383,26 +4307,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
         "json5": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -4590,9 +4494,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -4613,12 +4517,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.17.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+      "integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
@@ -4647,28 +4551,6 @@
         "@babel/code-frame": "^7.12.13",
         "@babel/parser": "^7.12.13",
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        }
       }
     },
     "@babel/traverse": {
@@ -4685,28 +4567,6 @@
         "@babel/types": "^7.13.17",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
-          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.12.13"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        }
       }
     },
     "@babel/types": {
@@ -5586,30 +5446,6 @@
           "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.4"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-          "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
           }
         },
         "ansi-regex": {
@@ -7095,12 +6931,12 @@
       }
     },
     "rollup": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.46.0.tgz",
-      "integrity": "sha512-qPGoUBNl+Z8uNu0z7pD3WPTABWRbcOwIrO/5ccDJzmrtzn0LVf6Lj91+L5CcWhXl6iWf23FQ6m8Jkl2CmN1O7Q==",
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.71.1.tgz",
+      "integrity": "sha512-lMZk3XfUBGjrrZQpvPSoXcZSfKcJ2Bgn+Z0L1MoW2V8Wh7BVM+LOBJTPo16yul2MwL59cXedzW1ruq3rCjSRgw==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.3.1"
+        "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-copy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.13.16",
         "@babel/eslint-parser": "^7.13.14",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.0.2",
         "copyfiles": "^2.4.1",
@@ -267,6 +268,15 @@
         "@babel/types": "^7.12.13"
       }
     },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.13.12",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
@@ -341,6 +351,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/template": {
@@ -4531,6 +4553,12 @@
         "@babel/types": "^7.12.13"
       }
     },
+    "@babel/helper-plugin-utils": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+      "dev": true
+    },
     "@babel/helper-replace-supers": {
       "version": "7.13.12",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
@@ -4600,6 +4628,15 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
       "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
       "dev": true
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
     },
     "@babel/template": {
       "version": "7.12.13",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,26 @@
   "main": "dist/photoswipe.esm.js",
   "style": "dist/photoswipe.css",
   "type": "module",
+  "types": "./dist/types/photoswipe.d.ts",
   "exports": {
-    ".": "./dist/photoswipe.esm.js",
-    "./lightbox": "./dist/photoswipe-lightbox.esm.js",
+    ".": {
+      "types": "./dist/types/photoswipe.d.ts",
+      "import": "./dist/photoswipe.esm.js"
+    },
+    "./lightbox": {
+      "types": "./dist/types/lightbox/lightbox.d.ts",
+      "import": "./dist/photoswipe-lightbox.esm.js"
+    },
     "./dist/photoswipe.css": "./dist/photoswipe.css",
     "./photoswipe.css": "./dist/photoswipe.css",
     "./style.css": "./dist/photoswipe.css"
+  },
+  "typesVersions": {
+    "<4.7": {
+      "lightbox": [
+        "dist/types/lightbox/lightbox.d.ts"
+      ]
+    }
   },
   "files": [
     "dist",
@@ -23,7 +37,7 @@
     "build": "npm run build-and-minify-js && npm run build-css && npm run copy-to-dist",
     "watch": "concurrently \"npm:watch-js\" \"npm:watch-css\" \"npm:watch-docs\"",
     "watch-local": "concurrently \"npm:watch-js\" \"npm:watch-css\" \"npm:watch-docs-local\"",
-    "build-and-minify-js": "rollup --config build/rollup.config.js",
+    "build-and-minify-js": "rollup --config build/rollup.config.js && npm run tsc",
     "watch-js": "rollup --config build/rollup.config.watch.js --watch",
     "build-css": "copyfiles -f src/*.css dist/ && copyfiles -f src/*.css demo-docs-website/static/photoswipe/",
     "watch-css": "chokidar \"src/*.css\" --command \"npm run build-css\"",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@babel/core": "^7.13.16",
     "@babel/eslint-parser": "^7.13.14",
+    "@babel/plugin-syntax-class-properties": "^7.12.13",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^6.0.2",
     "copyfiles": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "copy-to-dist": "copyfiles -f demo-docs-website/static/photoswipe/* dist/",
     "lint": "eslint src/js/**/*.js",
     "lint-auto-fix": "eslint src/js/**/*.js --fix",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "tsc": "tsc"
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",
@@ -45,7 +46,8 @@
     "eslint-plugin-import": "^2.22.1",
     "rollup": "^2.46.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "typescript": "^4.6.4"
   },
   "repository": {
     "type": "git",
@@ -66,6 +68,5 @@
     "zoom"
   ],
   "author": "Dmytro Semenov (https://dimsemenov.com)",
-  "license": "MIT",
-  "dependencies": {}
+  "license": "MIT"
 }

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -8,11 +8,12 @@ import {
 } from '../util/util.js';
 import Content from '../slide/content';
 
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
 /** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
 /** @typedef {import("../slide/slide").SlideData} SlideData */
 
 class PhotoSwipeBase extends Eventable {
-  /** @type {PhotoSwipeOptions} */
+  /** @type {Partial<PhotoSwipeOptions>} */
   options;
 
   /**
@@ -49,11 +50,11 @@ class PhotoSwipeBase extends Eventable {
   }
 
   /**
-   *
    * @param {SlideData} slideData
    * @param {number} index
    */
   createContentFromData(slideData, index) {
+    // @ts-expect-error
     return new Content(slideData, this, index);
   }
 

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -8,8 +8,13 @@ import {
 } from '../util/util.js';
 import Content from '../slide/content';
 
+/** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
+/** @typedef {import("../slide/slide").SlideData} SlideData */
 
 class PhotoSwipeBase extends Eventable {
+  /** @type {PhotoSwipeOptions} */
+  options;
+
   /**
    * Get total number of slides
    */
@@ -18,10 +23,10 @@ class PhotoSwipeBase extends Eventable {
     const { dataSource } = this.options;
     if (!dataSource) {
       numItems = 0;
-    } else if (dataSource.length) {
+    } else if ('length' in dataSource) {
       // may be an array or just object with length property
       numItems = dataSource.length;
-    } else if (dataSource.gallery) {
+    } else if ('gallery' in dataSource) {
       // query DOM elements
       if (!dataSource.items) {
         dataSource.items = this._getGalleryDOMElements(dataSource.gallery);
@@ -37,9 +42,15 @@ class PhotoSwipeBase extends Eventable {
       dataSource,
       numItems
     });
+    // @ts-expect-error TODO
     return this.applyFilters('numItems', event.numItems, dataSource);
   }
 
+  /**
+   *
+   * @param {SlideData} slideData
+   * @param {number} index
+   */
   createContentFromData(slideData, index) {
     return new Content(slideData, this, index);
   }
@@ -51,7 +62,7 @@ class PhotoSwipeBase extends Eventable {
    * For example, it may contain properties like
    * `src`, `srcset`, `w`, `h`, which will be used to generate a slide with image.
    *
-   * @param {Integer} index
+   * @param {number} index
    */
   getItemData(index) {
     const { dataSource } = this.options;
@@ -85,6 +96,7 @@ class PhotoSwipeBase extends Eventable {
       index
     });
 
+    // @ts-expect-error TODO
     return this.applyFilters('itemData', event.itemData, index);
   }
 
@@ -92,7 +104,7 @@ class PhotoSwipeBase extends Eventable {
    * Get array of gallery DOM elements,
    * based on childSelector and gallery element.
    *
-   * @param {Element} galleryElement
+   * @param {HTMLElement} galleryElement
    */
   _getGalleryDOMElements(galleryElement) {
     if (this.options.children || this.options.childSelector) {
@@ -109,20 +121,22 @@ class PhotoSwipeBase extends Eventable {
   /**
    * Converts DOM element to item data object.
    *
-   * @param {Element} element DOM element
+   * @param {HTMLElement} element DOM element
    */
   // eslint-disable-next-line class-methods-use-this
   _domElementToItemData(element) {
+    /** @type {SlideData} */
     const itemData = {
       element
     };
 
+    /** @type {HTMLElement | HTMLAnchorElement} */
     const linkEl = element.tagName === 'A' ? element : element.querySelector('a');
 
     if (linkEl) {
       // src comes from data-pswp-src attribute,
       // if it's empty link href is used
-      itemData.src = linkEl.dataset.pswpSrc || linkEl.href;
+      itemData.src = linkEl.dataset.pswpSrc || /** @type {HTMLAnchorElement} */ (linkEl).href;
 
       if (linkEl.dataset.pswpSrcset) {
         itemData.srcset = linkEl.dataset.pswpSrcset;

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -45,7 +45,6 @@ class PhotoSwipeBase extends Eventable {
       dataSource,
       numItems
     });
-    // @ts-expect-error TODO
     return this.applyFilters('numItems', event.numItems, dataSource);
   }
 
@@ -99,7 +98,6 @@ class PhotoSwipeBase extends Eventable {
       index
     });
 
-    // @ts-expect-error TODO
     return this.applyFilters('itemData', event.itemData, index);
   }
 

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -17,6 +17,8 @@ class PhotoSwipeBase extends Eventable {
 
   /**
    * Get total number of slides
+   *
+   * @returns {number}
    */
   getNumItems() {
     let numItems;

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -1,7 +1,3 @@
-/**
- * PhotoSwipe base class that can retrieve data about every slide.
- * Shared by PhotoSwipe Core and PhotoSwipe Lightbox
- */
 import Eventable from './eventable';
 import {
   getElementsFromOption
@@ -12,6 +8,10 @@ import Content from '../slide/content';
 /** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
 /** @typedef {import("../slide/slide").SlideData} SlideData */
 
+/**
+ * PhotoSwipe base class that can retrieve data about every slide.
+ * Shared by PhotoSwipe Core and PhotoSwipe Lightbox
+ */
 class PhotoSwipeBase extends Eventable {
   /** @type {PhotoSwipeOptions} */
   options;

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -13,7 +13,7 @@ import Content from '../slide/content';
 /** @typedef {import("../slide/slide").SlideData} SlideData */
 
 class PhotoSwipeBase extends Eventable {
-  /** @type {Partial<PhotoSwipeOptions>} */
+  /** @type {PhotoSwipeOptions} */
   options;
 
   /**

--- a/src/js/core/base.js
+++ b/src/js/core/base.js
@@ -131,13 +131,13 @@ class PhotoSwipeBase extends Eventable {
       element
     };
 
-    /** @type {HTMLElement | HTMLAnchorElement} */
-    const linkEl = element.tagName === 'A' ? element : element.querySelector('a');
+    // eslint-disable-next-line max-len
+    const linkEl = /** @type {HTMLAnchorElement} */ (element.tagName === 'A' ? element : element.querySelector('a'));
 
     if (linkEl) {
       // src comes from data-pswp-src attribute,
       // if it's empty link href is used
-      itemData.src = linkEl.dataset.pswpSrc || /** @type {HTMLAnchorElement} */ (linkEl).href;
+      itemData.src = linkEl.dataset.pswpSrc || linkEl.href;
 
       if (linkEl.dataset.pswpSrcset) {
         itemData.srcset = linkEl.dataset.pswpSrcset;

--- a/src/js/core/eventable.js
+++ b/src/js/core/eventable.js
@@ -30,13 +30,11 @@ class Eventable {
   constructor() {
     /**
      * @type {Record<string, (() => any)[]>}
-     * @private
      */
     this._listeners = {};
 
     /**
      * @type {Record<string, Filter[]>}
-     * @private
      */
     this._filters = {};
 

--- a/src/js/core/eventable.js
+++ b/src/js/core/eventable.js
@@ -11,7 +11,7 @@
 /** @typedef {{ x?: number; y?: number }} Point */
 
 /**
- * @typedef {Object} PhotoSwipeEventsMap
+ * @typedef {Object} PhotoSwipeEventsMap https://photoswipe.com/events/
  *
  *
  * https://photoswipe.com/adding-ui-elements/
@@ -119,7 +119,7 @@
  */
 
 /**
- * @typedef {Object} PhotoSwipeFiltersMap
+ * @typedef {Object} PhotoSwipeFiltersMap https://photoswipe.com/filters/
  *
  * @prop {(numItems: number, dataSource: DataSource) => number} numItems
  * Modify the total amount of slides. Example on Data sources page.

--- a/src/js/core/eventable.js
+++ b/src/js/core/eventable.js
@@ -93,7 +93,7 @@
  * @prop {{ slide: Slide }} slideActivate
  * @prop {{ slide: Slide }} slideDeactivate
  * @prop {{ slide: Slide }} slideDestroy
- * @prop {{ destZoomLevel: number, centerPoint: Point, transitionDuration: number }} beforeZoomTo
+ * @prop {{ destZoomLevel: number, centerPoint: Point, transitionDuration: number | false }} beforeZoomTo
  * @prop {{ slide: Slide }} zoomPanUpdate
  * @prop {{ slide: Slide }} initialZoomPan
  * @prop {{ slide: Slide }} calcSlideSize

--- a/src/js/core/eventable.js
+++ b/src/js/core/eventable.js
@@ -2,12 +2,17 @@
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
 /** @typedef {import("../photoswipe").DataSource} DataSource */
 /** @typedef {import("../ui/ui-element").UIElementData} UIElementData */
-/** @typedef {import("../slide/content").default} Content */
+/** @typedef {import("../slide/content").default} ContentDefault */
 /** @typedef {import("../slide/slide").default} Slide */
 /** @typedef {import("../slide/slide").SlideData} SlideData */
 /** @typedef {import("../slide/zoom-level").default} ZoomLevel */
 /** @typedef {import("../slide/get-thumb-bounds").Bounds} Bounds */
 
+/**
+ * Allow adding an arbitrary props to the Content
+ * https://photoswipe.com/custom-content/#using-webp-image-format
+ * @typedef {ContentDefault & Record<string, any>} Content
+ */
 /** @typedef {{ x?: number; y?: number }} Point */
 
 /**

--- a/src/js/core/eventable.js
+++ b/src/js/core/eventable.js
@@ -134,7 +134,7 @@
  * Modify slide item data. Example on Data sources page.
  * https://photoswipe.com/filters/#itemdata
  *
- * @prop {(itemData: SlideData, element: HTMLElement, linkEl: HTMLElement) => SlideData} domItemData
+ * @prop {(itemData: SlideData, element: HTMLElement, linkEl: HTMLAnchorElement) => SlideData} domItemData
  * Modify item data when it's parsed from DOM element. Example on Data sources page.
  * https://photoswipe.com/filters/#domitemdata
  *

--- a/src/js/core/eventable.js
+++ b/src/js/core/eventable.js
@@ -1,12 +1,199 @@
+/** @typedef {import("../lightbox/lightbox").default} PhotoSwipeLightbox */
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("../photoswipe").DataSource} DataSource */
+/** @typedef {import("../ui/ui-element").UIElementData} UIElementData */
+/** @typedef {import("../slide/content").default} Content */
+/** @typedef {import("../slide/slide").default} Slide */
+/** @typedef {import("../slide/slide").SlideData} SlideData */
+/** @typedef {import("../slide/zoom-level").default} ZoomLevel */
+/** @typedef {import("../slide/get-thumb-bounds").Bounds} Bounds */
+
+/** @typedef {{ x?: number; y?: number }} Point */
+
+/**
+ * @typedef {Object} PhotoSwipeEventsMap
+ *
+ *
+ * https://photoswipe.com/adding-ui-elements/
+ *
+ * @prop {undefined} uiRegister
+ * @prop {{ data: UIElementData }} uiElementCreate
+ *
+ *
+ * https://photoswipe.com/events/#initialization-events
+ *
+ * @prop {undefined} beforeOpen
+ * @prop {undefined} firstUpdate
+ * @prop {undefined} initialLayout
+ * @prop {undefined} change
+ * @prop {undefined} afterInit
+ * @prop {undefined} bindEvents
+ *
+ *
+ * https://photoswipe.com/events/#opening-or-closing-transition-events
+ *
+ * @prop {undefined} openingAnimationStart
+ * @prop {undefined} openingAnimationEnd
+ * @prop {undefined} closingAnimationStart
+ * @prop {undefined} closingAnimationEnd
+ *
+ *
+ * https://photoswipe.com/events/#closing-events
+ *
+ * @prop {undefined} close
+ * @prop {undefined} destroy
+ *
+ *
+ * https://photoswipe.com/events/#pointer-and-gesture-events
+ *
+ * @prop {{ originalEvent: PointerEvent }} pointerDown
+ * @prop {{ originalEvent: PointerEvent }} pointerMove
+ * @prop {{ originalEvent: PointerEvent }} pointerUp
+ * @prop {{ bgOpacity: number }} pinchClose can be default prevented
+ * @prop {{ panY: number }} verticalDrag can be default prevented
+ *
+ *
+ * https://photoswipe.com/events/#slide-content-events
+ *
+ * @prop {{ content: Content }} contentInit
+ * @prop {{ content: Content; isLazy: boolean }} contentLoad can be default prevented
+ * @prop {{ content: Content; isLazy: boolean }} contentLoadImage can be default prevented
+ * @prop {{ content: Content; slide: Slide; isError?: boolean }} loadComplete
+ * @prop {{ content: Content; slide: Slide }} loadError
+ * @prop {{ content: Content; width: number; height: number }} contentResize can be default prevented
+ * @prop {{ content: Content; width: number; height: number; slide: Slide }} imageSizeChange
+ * @prop {{ content: Content }} contentLazyLoad can be default prevented
+ * @prop {{ content: Content }} contentAppend can be default prevented
+ * @prop {{ content: Content }} contentActivate can be default prevented
+ * @prop {{ content: Content }} contentDeactivate can be default prevented
+ * @prop {{ content: Content }} contentRemove can be default prevented
+ * @prop {{ content: Content }} contentDestroy can be default prevented
+ *
+ *
+ * undocumented
+ *
+ * @prop {{ point: Point; originalEvent: PointerEvent }} imageClickAction can be default prevented
+ * @prop {{ point: Point; originalEvent: PointerEvent }} bgClickAction can be default prevented
+ * @prop {{ point: Point; originalEvent: PointerEvent }} tapAction can be default prevented
+ * @prop {{ point: Point; originalEvent: PointerEvent }} doubleTapAction can be default prevented
+ *
+ * @prop {{ originalEvent: KeyboardEvent }} keydown can be default prevented
+ * @prop {{ x: number; dragging: boolean }} moveMainScroll
+ * @prop {{ slide: Slide }} firstZoomPan
+ * @prop {{ slide: Slide, data: SlideData, index: number }} gettingData
+ * @prop {undefined} beforeResize
+ * @prop {undefined} resize
+ * @prop {undefined} viewportSize
+ * @prop {undefined} updateScrollOffset
+ * @prop {{ slide: Slide }} slideInit
+ * @prop {{ slide: Slide }} afterSetContent
+ * @prop {{ slide: Slide }} slideLoad
+ * @prop {{ slide: Slide }} appendHeavy can be default prevented
+ * @prop {{ slide: Slide }} appendHeavyContent
+ * @prop {{ slide: Slide }} slideActivate
+ * @prop {{ slide: Slide }} slideDeactivate
+ * @prop {{ slide: Slide }} slideDestroy
+ * @prop {{ destZoomLevel: number, centerPoint: Point, transitionDuration: number }} beforeZoomTo
+ * @prop {{ slide: Slide }} zoomPanUpdate
+ * @prop {{ slide: Slide }} initialZoomPan
+ * @prop {{ slide: Slide }} calcSlideSize
+ * @prop {undefined} resolutionChanged
+ * @prop {{ originalEvent: WheelEvent }} wheel can be default prevented
+ * @prop {{ content: Content }} contentAppendImage can be default prevented
+ * @prop {{ index: number; itemData: SlideData }} lazyLoadSlide can be default prevented
+ * @prop {undefined} lazyLoad
+ * @prop {{ slide: Slide }} calcBounds
+ * @prop {{ zoomLevels: ZoomLevel, slideData: SlideData }} zoomLevelsUpdate
+ *
+ *
+ * legacy
+ *
+ * @prop {undefined} init
+ * @prop {undefined} initialZoomIn
+ * @prop {undefined} initialZoomOut
+ * @prop {undefined} initialZoomInEnd
+ * @prop {undefined} initialZoomOutEnd
+ * @prop {{ dataSource: DataSource, numItems: number }} numItems
+ * @prop {{ itemData: SlideData; index: number }} itemData
+ * @prop {{ index: number, itemData: SlideData, instance: PhotoSwipe }} thumbBounds
+ */
+
+/**
+ * @typedef {Object} PhotoSwipeFiltersMap
+ *
+ * @prop {(numItems: number, dataSource: DataSource) => number} numItems
+ * Modify the total amount of slides. Example on Data sources page.
+ * https://photoswipe.com/filters/#numitems
+ *
+ * @prop {(itemData: SlideData, index: number) => SlideData} itemData
+ * Modify slide item data. Example on Data sources page.
+ * https://photoswipe.com/filters/#itemdata
+ *
+ * @prop {(itemData: SlideData, element: HTMLElement, linkEl: HTMLElement) => SlideData} domItemData
+ * Modify item data when it's parsed from DOM element. Example on Data sources page.
+ * https://photoswipe.com/filters/#domitemdata
+ *
+ * @prop {(clickedIndex: number, e: MouseEvent, instance: PhotoSwipeLightbox) => number} clickedIndex
+ * Modify clicked gallery item index.
+ * https://photoswipe.com/filters/#clickedindex
+ *
+ * @prop {(placeholderSrc: string | false, content: Content) => string | false} placeholderSrc
+ * Modify placeholder image source.
+ * https://photoswipe.com/filters/#placeholdersrc
+ *
+ * @prop {(isContentLoading: boolean, content: Content) => boolean} isContentLoading
+ * Modify if the content is currently loading.
+ * https://photoswipe.com/filters/#iscontentloading
+ *
+ * @prop {(isContentZoomable: boolean, content: Content) => boolean} isContentZoomable
+ * Modify if the content can be zoomed.
+ * https://photoswipe.com/filters/#iscontentzoomable
+ *
+ * @prop {(useContentPlaceholder: boolean, content: Content) => boolean} useContentPlaceholder
+ * Modify if the placeholder should be used for the content.
+ * https://photoswipe.com/filters/#usecontentplaceholder
+ *
+ * @prop {(isKeepingPlaceholder: boolean, content: Content) => boolean} isKeepingPlaceholder
+ * Modify if the placeholder should be kept after the content is loaded.
+ * https://photoswipe.com/filters/#iskeepingplaceholder
+ *
+ *
+ * @prop {(contentErrorElement: HTMLElement, content: Content) => HTMLElement} contentErrorElement
+ * Modify an element when the content has error state (for example, if image cannot be loaded).
+ * https://photoswipe.com/filters/#contenterrorelement
+ *
+ * @prop {(element: HTMLElement, data: UIElementData) => HTMLElement} uiElement
+ * Modify a UI element that's being created.
+ * https://photoswipe.com/filters/#uielement
+ *
+ * @prop {(thumbnail: HTMLElement, itemData: SlideData, index: number) => HTMLElement} thumbEl
+ * Modify the thubmnail element from which opening zoom animation starts or ends.
+ * https://photoswipe.com/filters/#thumbel
+ *
+ * @prop {(thumbBounds: Bounds, itemData: SlideData, index: number) => Bounds} thumbBounds
+ * Modify the thubmnail bounds from which opening zoom animation starts or ends.
+ * https://photoswipe.com/filters/#thumbbounds
+ */
+
+/**
+ * @template {keyof PhotoSwipeFiltersMap} T
+ * @typedef {{ fn: PhotoSwipeFiltersMap[T], priority: number }} Filter<T>
+ */
+
+/**
+ * @template {keyof PhotoSwipeEventsMap} T
+ * @typedef {PhotoSwipeEventsMap[T] extends undefined ? PhotoSwipeEvent<T> : PhotoSwipeEvent<T> & PhotoSwipeEventsMap[T]} AugmentedEvent
+ */
 
 /**
  * Base PhotoSwipe event object
+ *
+ * @template {keyof PhotoSwipeEventsMap} T
  */
 class PhotoSwipeEvent {
   /**
-   * @param {string} type
-   * @param {Record<string, any>} [details]
+   * @param {T} type
+   * @param {PhotoSwipeEventsMap[T]} [details]
    */
   constructor(type, details) {
     this.type = type;
@@ -20,8 +207,6 @@ class PhotoSwipeEvent {
   }
 }
 
-/** @typedef {{ fn: () => any, priority: number }} Filter */
-
 /**
  * PhotoSwipe base class that can listen and dispatch for events.
  * Shared by PhotoSwipe Core and PhotoSwipe Lightbox, extended by base.js
@@ -29,12 +214,12 @@ class PhotoSwipeEvent {
 class Eventable {
   constructor() {
     /**
-     * @type {Record<string, (() => any)[]>}
+     * @type {{ [T in keyof PhotoSwipeEventsMap]?: ((event: AugmentedEvent<T>) => void)[] }}
      */
     this._listeners = {};
 
     /**
-     * @type {Record<string, Filter[]>}
+     * @type {{ [T in keyof PhotoSwipeFiltersMap]?: Filter<T>[] }}
      */
     this._filters = {};
 
@@ -43,8 +228,9 @@ class Eventable {
   }
 
   /**
-   * @param {string} name
-   * @param {() => any} fn
+   * @template {keyof PhotoSwipeFiltersMap} T
+   * @param {T} name
+   * @param {PhotoSwipeFiltersMap[T]} fn
    * @param {number} priority
    */
   addFilter(name, fn, priority = 100) {
@@ -61,11 +247,13 @@ class Eventable {
   }
 
   /**
-   * @param {string} name
-   * @param {() => any} fn
+   * @template {keyof PhotoSwipeFiltersMap} T
+   * @param {T} name
+   * @param {PhotoSwipeFiltersMap[T]} fn
    */
   removeFilter(name, fn) {
     if (this._filters[name]) {
+      // @ts-expect-error
       this._filters[name] = this._filters[name].filter(filter => (filter.fn !== fn));
     }
 
@@ -75,13 +263,15 @@ class Eventable {
   }
 
   /**
-   * @param {string} name
-   * @param  {any[]} args
+   * @template {keyof PhotoSwipeFiltersMap} T
+   * @param {T} name
+   * @param {Parameters<PhotoSwipeFiltersMap[T]>} args
+   * @returns {Parameters<PhotoSwipeFiltersMap[T]>[0]}
    */
   applyFilters(name, ...args) {
     if (this._filters[name]) {
       this._filters[name].forEach((filter) => {
-        // @ts-expect-error TODO
+        // @ts-expect-error
         args[0] = filter.fn.apply(this, args);
       });
     }
@@ -89,8 +279,9 @@ class Eventable {
   }
 
   /**
-   * @param {string} name
-   * @param {() => any} fn
+   * @template {keyof PhotoSwipeEventsMap} T
+   * @param {T} name
+   * @param {(event: AugmentedEvent<T>) => void} fn
    */
   on(name, fn) {
     if (!this._listeners[name]) {
@@ -107,11 +298,13 @@ class Eventable {
   }
 
   /**
-   * @param {string} name
-   * @param {() => any} fn
+   * @template {keyof PhotoSwipeEventsMap} T
+   * @param {T} name
+   * @param {(event: AugmentedEvent<T>) => void} fn
    */
   off(name, fn) {
     if (this._listeners[name]) {
+      // @ts-expect-error
       this._listeners[name] = this._listeners[name].filter(listener => (fn !== listener));
     }
 
@@ -121,16 +314,17 @@ class Eventable {
   }
 
   /**
-   * @param {string} name
-   * @param {Record<string, any>} [details]
-   * @returns {PhotoSwipeEvent}
+   * @template {keyof PhotoSwipeEventsMap} T
+   * @param {T} name
+   * @param {PhotoSwipeEventsMap[T]} [details]
+   * @returns {AugmentedEvent<T>}
    */
   dispatch(name, details) {
     if (this.pswp) {
       return this.pswp.dispatch(name, details);
     }
 
-    const event = new PhotoSwipeEvent(name, details);
+    const event = /** @type {AugmentedEvent<T>} */ (new PhotoSwipeEvent(name, details));
 
     if (!this._listeners) {
       return event;
@@ -138,7 +332,6 @@ class Eventable {
 
     if (this._listeners[name]) {
       this._listeners[name].forEach((listener) => {
-        // @ts-expect-error TODO
         listener.call(this, event);
       });
     }

--- a/src/js/core/eventable.js
+++ b/src/js/core/eventable.js
@@ -191,6 +191,11 @@
  */
 
 /**
+ * @template {keyof PhotoSwipeEventsMap} T
+ * @typedef {(event: AugmentedEvent<T>) => void} EventCallback<T>
+ */
+
+/**
  * Base PhotoSwipe event object
  *
  * @template {keyof PhotoSwipeEventsMap} T
@@ -286,7 +291,7 @@ class Eventable {
   /**
    * @template {keyof PhotoSwipeEventsMap} T
    * @param {T} name
-   * @param {(event: AugmentedEvent<T>) => void} fn
+   * @param {EventCallback<T>} fn
    */
   on(name, fn) {
     if (!this._listeners[name]) {
@@ -305,7 +310,7 @@ class Eventable {
   /**
    * @template {keyof PhotoSwipeEventsMap} T
    * @param {T} name
-   * @param {(event: AugmentedEvent<T>) => void} fn
+   * @param {EventCallback<T>} fn
    */
   off(name, fn) {
     if (this._listeners[name]) {

--- a/src/js/gestures/drag-handler.js
+++ b/src/js/gestures/drag-handler.js
@@ -6,6 +6,9 @@ import {
   equalizePoints, roundPoint, clamp
 } from '../util/util.js';
 
+/** @typedef {import("../photoswipe").Point} Point */
+/** @typedef {import("./gestures").default} Gestures */
+
 const PAN_END_FRICTION = 0.35;
 const VERTICAL_DRAG_FRICTION = 0.6;
 
@@ -16,14 +19,22 @@ const MIN_RATIO_TO_CLOSE = 0.4;
 // to next or previous slide
 const MIN_NEXT_SLIDE_SPEED = 0.5;
 
+/**
+ * @param {number} initialVelocity
+ * @param {number} decelerationRate
+ */
 function project(initialVelocity, decelerationRate) {
   return initialVelocity * decelerationRate / (1 - decelerationRate);
 }
 
 class DragHandler {
+  /**
+   * @param {Gestures} gestures
+   */
   constructor(gestures) {
     this.gestures = gestures;
     this.pswp = gestures.pswp;
+    /** @type {Point} */
     this.startPan = {};
   }
 
@@ -114,6 +125,10 @@ class DragHandler {
     }
   }
 
+  /**
+   * @private
+   * @param {'x' | 'y'} axis
+   */
   _finishPanGestureForAxis(axis) {
     const { pswp } = this;
     const { currSlide } = pswp;
@@ -192,7 +207,8 @@ class DragHandler {
    *
    * Should return true if it changes (or can change) main scroll.
    *
-   * @param {String} axis
+   * @private
+   * @param {'x' | 'y'} axis
    */
   _panOrMoveMainScroll(axis) {
     const { p1, pswp, dragAxis, prevP1, isMultitouch } = this.gestures;
@@ -292,7 +308,8 @@ class DragHandler {
    * if position is shifted upwards - the ratio is negative,
    * if position is shifted downwards - the ratio is positive.
    *
-   * @param {Number} panY The current pan Y position.
+   * @private
+   * @param {number} panY The current pan Y position.
    */
   _getVerticalDragRatio(panY) {
     return (panY - this.pswp.currSlide.bounds.center.y)
@@ -304,9 +321,10 @@ class DragHandler {
    * Apply friction if the position is beyond the pan bounds,
    * or if custom friction is defined.
    *
-   * @param {String} axis
-   * @param {Number} potentialPan
-   * @param {Number|null} customFriction (0.1 - 1)
+   * @private
+   * @param {'x' | 'y'} axis
+   * @param {number} potentialPan
+   * @param {number=} customFriction (0.1 - 1)
    */
   _setPanWithFriction(axis, potentialPan, customFriction) {
     const { pan, bounds } = this.pswp.currSlide;

--- a/src/js/gestures/drag-handler.js
+++ b/src/js/gestures/drag-handler.js
@@ -1,7 +1,3 @@
-/**
- * Handles single pointer dragging
- */
-
 import {
   equalizePoints, roundPoint, clamp
 } from '../util/util.js';
@@ -27,6 +23,9 @@ function project(initialVelocity, decelerationRate) {
   return initialVelocity * decelerationRate / (1 - decelerationRate);
 }
 
+/**
+ * Handles single pointer dragging
+ */
 class DragHandler {
   /**
    * @param {Gestures} gestures

--- a/src/js/gestures/gestures.js
+++ b/src/js/gestures/gestures.js
@@ -1,10 +1,3 @@
-/**
- * Gestures class bind touch, pointer or mouse events
- * and emits drag to drag-handler and zoom events zoom-handler.
- *
- * Drag and zoom events are emited in requestAnimationFrame,
- * and only when one of pointers was actually changed.
- */
 import {
   equalizePoints, pointsEqual, getDistanceBetween
 } from '../util/util.js';
@@ -24,6 +17,13 @@ const AXIS_SWIPE_HYSTERISIS = 10;
 const DOUBLE_TAP_DELAY = 300; // ms
 const MIN_TAP_DISTANCE = 25; // px
 
+/**
+ * Gestures class bind touch, pointer or mouse events
+ * and emits drag to drag-handler and zoom events zoom-handler.
+ *
+ * Drag and zoom events are emited in requestAnimationFrame,
+ * and only when one of pointers was actually changed.
+ */
 class Gestures {
   /** @type {'x' | 'y'} */
   dragAxis;

--- a/src/js/gestures/gestures.js
+++ b/src/js/gestures/gestures.js
@@ -13,6 +13,9 @@ import DragHandler from './drag-handler.js';
 import ZoomHandler from './zoom-handler.js';
 import TapHandler from './tap-handler.js';
 
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("../photoswipe").Point} Point */
+
 // How far should user should drag
 // until we can determine that the gesture is swipe and its direction
 const AXIS_SWIPE_HYSTERISIS = 10;
@@ -22,23 +25,39 @@ const DOUBLE_TAP_DELAY = 300; // ms
 const MIN_TAP_DISTANCE = 25; // px
 
 class Gestures {
+  /** @type {'x' | 'y'} */
+  dragAxis;
+
+  /**
+   * @param {PhotoSwipe} pswp
+   */
   constructor(pswp) {
     this.pswp = pswp;
 
 
     // point objects are defined once and reused
     // PhotoSwipe keeps track only of two pointers, others are ignored
+    /** @type {Point} */
     this.p1 = {}; // the first pressed pointer
+    /** @type {Point} */
     this.p2 = {}; // the second pressed pointer
+    /** @type {Point} */
     this.prevP1 = {};
+    /** @type {Point} */
     this.prevP2 = {};
+    /** @type {Point} */
     this.startP1 = {};
+    /** @type {Point} */
     this.startP2 = {};
+    /** @type {Point} */
     this.velocity = {};
 
+    /** @type {Point} */
     this._lastStartP1 = {};
+    /** @type {Point} */
     this._intervalP1 = {};
     this._numActivePoints = 0;
+    /** @type {Point[]} */
     this._ongoingPointers = [];
 
     this._touchEventEnabled = 'ontouchstart' in window;
@@ -79,6 +98,13 @@ class Gestures {
     });
   }
 
+  /**
+   *
+   * @param {'mouse' | 'touch' | 'pointer'} pref
+   * @param {'down' | 'start'} down
+   * @param {'up' | 'end'} up
+   * @param {'cancel'} [cancel]
+   */
   _bindEvents(pref, down, up, cancel) {
     const { pswp } = this;
     const { events } = pswp;
@@ -93,7 +119,9 @@ class Gestures {
     }
   }
 
-
+  /**
+   * @param {PointerEvent} e
+   */
   onPointerDown(e) {
     // We do not call preventDefault for touch events
     // to allow browser to show native dialog on longpress
@@ -155,6 +183,9 @@ class Gestures {
     }
   }
 
+  /**
+   * @param {PointerEvent} e
+   */
   onPointerMove(e) {
     e.preventDefault(); // always preventDefault move event
 
@@ -211,6 +242,9 @@ class Gestures {
     }
   }
 
+  /**
+   * @private
+   */
   _finishDrag() {
     if (this.isDragging) {
       this.isDragging = false;
@@ -226,7 +260,9 @@ class Gestures {
     }
   }
 
-
+  /**
+   * @param {PointerEvent} e
+   */
   onPointerUp(e) {
     if (!this._numActivePoints) {
       return;
@@ -262,7 +298,9 @@ class Gestures {
     }
   }
 
-
+  /**
+   * @private
+   */
   _rafRenderLoop() {
     if (this.isDragging || this.isZooming) {
       this._updateVelocity();
@@ -286,6 +324,8 @@ class Gestures {
 
   /**
    * Update velocity at 50ms interval
+   *
+   * @param {boolean=} force
    */
   _updateVelocity(force) {
     const time = Date.now();
@@ -304,6 +344,10 @@ class Gestures {
     this._velocityCalculated = true;
   }
 
+  /**
+   * @private
+   * @param {PointerEvent} e
+   */
   _finishTap(e) {
     const { mainScroll } = this.pswp;
 
@@ -347,6 +391,9 @@ class Gestures {
     }
   }
 
+  /**
+   * @private
+   */
   _clearTapTimer() {
     if (this._tapTimer) {
       clearTimeout(this._tapTimer);
@@ -357,8 +404,9 @@ class Gestures {
   /**
    * Get velocity for axis
    *
-   * @param {Number} axis
-   * @param {Number} duration
+   * @private
+   * @param {'x' | 'y'} axis
+   * @param {number} duration
    */
   _getVelocity(axis, duration) {
     // displacement is like distance, but can be negative.
@@ -371,6 +419,9 @@ class Gestures {
     return 0;
   }
 
+  /**
+   * @private
+   */
   _rafStopLoop() {
     if (this.raf) {
       cancelAnimationFrame(this.raf);
@@ -378,7 +429,10 @@ class Gestures {
     }
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  /**
+   * @private
+   * @param {PointerEvent} e
+   */
   _preventPointerEventBehaviour(e) {
     // TODO find a way to disable e.preventDefault on some elements
     //      via event or some class or something
@@ -390,14 +444,16 @@ class Gestures {
    * Parses and normalizes points from the touch, mouse or pointer event.
    * Updates p1 and p2.
    *
-   * @param {Event} e
-   * @param {String} pointerType Normalized pointer type ('up', 'down' or 'move')
+   * @private
+   * @param {PointerEvent | TouchEvent} e
+   * @param {'up' | 'down' | 'move'} pointerType Normalized pointer type
    */
   _updatePoints(e, pointerType) {
     if (this._pointerEventEnabled) {
+      const pointerEvent = /** @type {PointerEvent} */ (e);
       // Try to find the current pointer in ongoing pointers by its ID
       const pointerIndex = this._ongoingPointers.findIndex((ongoingPoiner) => {
-        return ongoingPoiner.id === e.pointerId;
+        return ongoingPoiner.id === pointerEvent.pointerId;
       });
 
       if (pointerType === 'up' && pointerIndex > -1) {
@@ -405,10 +461,10 @@ class Gestures {
         this._ongoingPointers.splice(pointerIndex, 1);
       } else if (pointerType === 'down' && pointerIndex === -1) {
         // add new pointer
-        this._ongoingPointers.push(this._convertEventPosToPoint(e, {}));
+        this._ongoingPointers.push(this._convertEventPosToPoint(pointerEvent, {}));
       } else if (pointerIndex > -1) {
         // update existing pointer
-        this._convertEventPosToPoint(e, this._ongoingPointers[pointerIndex]);
+        this._convertEventPosToPoint(pointerEvent, this._ongoingPointers[pointerIndex]);
       }
 
       this._numActivePoints = this._ongoingPointers.length;
@@ -423,21 +479,23 @@ class Gestures {
         equalizePoints(this.p2, this._ongoingPointers[1]);
       }
     } else {
+      const touchEvent = /** @type {TouchEvent} */ (e);
+
       this._numActivePoints = 0;
-      if (e.type.indexOf('touch') > -1) {
+      if (touchEvent.type.indexOf('touch') > -1) {
         // Touch Event
         // https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
-        if (e.touches && e.touches.length > 0) {
-          this._convertEventPosToPoint(e.touches[0], this.p1);
+        if (touchEvent.touches && touchEvent.touches.length > 0) {
+          this._convertEventPosToPoint(touchEvent.touches[0], this.p1);
           this._numActivePoints++;
-          if (e.touches.length > 1) {
-            this._convertEventPosToPoint(e.touches[1], this.p2);
+          if (touchEvent.touches.length > 1) {
+            this._convertEventPosToPoint(touchEvent.touches[1], this.p2);
             this._numActivePoints++;
           }
         }
       } else {
         // Mouse Event
-        this._convertEventPosToPoint(e, this.p1);
+        this._convertEventPosToPoint(/** @type {PointerEvent} */ (e), this.p1);
         if (pointerType === 'up') {
           // clear all points on mouseup
           this._numActivePoints = 0;
@@ -484,15 +542,15 @@ class Gestures {
    * Converts touch, pointer or mouse event
    * to PhotoSwipe point.
    *
-   * @param {Event} e
+   * @private
+   * @param {Touch | PointerEvent} e
    * @param {Point} p
    */
   _convertEventPosToPoint(e, p) {
     p.x = e.pageX - this.pswp.offset.x;
     p.y = e.pageY - this.pswp.offset.y;
 
-    // e.pointerId can be zero
-    if (e.pointerId !== undefined) {
+    if ('pointerId' in e) {
       p.id = e.pointerId;
     } else if (e.identifier !== undefined) {
       p.id = e.identifier;
@@ -501,6 +559,10 @@ class Gestures {
     return p;
   }
 
+  /**
+   * @private
+   * @param {PointerEvent} e
+   */
   _onClick(e) {
     // Do not allow click event to pass through after drag
     if (this.pswp.mainScroll.isShifted()) {

--- a/src/js/gestures/tap-handler.js
+++ b/src/js/gestures/tap-handler.js
@@ -77,10 +77,10 @@ class TapHandler {
   _doClickOrTapAction(actionName, point, originalEvent) {
     const { pswp } = this.gestures;
     const { currSlide } = pswp;
-    // eslint-disable-next-line max-len
-    const optionValue = pswp.options[/** @type {AddPostfix<Actions, 'Action'>} */ (actionName + 'Action')];
+    const actionFullName = /** @type {AddPostfix<Actions, 'Action'>} */ (actionName + 'Action');
+    const optionValue = pswp.options[actionFullName];
 
-    if (pswp.dispatch(actionName + 'Action', { point, originalEvent }).defaultPrevented) {
+    if (pswp.dispatch(actionFullName, { point, originalEvent }).defaultPrevented) {
       return;
     }
 

--- a/src/js/gestures/tap-handler.js
+++ b/src/js/gestures/tap-handler.js
@@ -2,24 +2,35 @@
  * Tap, double-tap handler.
  */
 
+/** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
+/** @typedef {import("./gestures").default} Gestures */
+
+/** @typedef {{ x?: number; y?: number }} Point */
+
 /**
  * Whether the tap was performed on the main slide
  * (rather than controls or caption).
  *
- * @param {Event} event
+ * @param {PointerEvent} event
  */
 function didTapOnMainContent(event) {
-  return !!(event.target.closest('.pswp__container'));
+  return !!(/** @type {HTMLElement} */ (event.target).closest('.pswp__container'));
 }
 
 class TapHandler {
+  /**
+   * @param {Gestures} gestures
+   */
   constructor(gestures) {
     this.gestures = gestures;
   }
 
-
+  /**
+   * @param {Point} point
+   * @param {PointerEvent} originalEvent
+   */
   click(point, originalEvent) {
-    const targetClassList = originalEvent.target.classList;
+    const targetClassList = /** @type {HTMLElement} */ (originalEvent.target).classList;
     const isImageClick = targetClassList.contains('pswp__img');
     const isBackgroundClick = targetClassList.contains('pswp__item')
                               || targetClassList.contains('pswp__zoom-wrap');
@@ -31,22 +42,38 @@ class TapHandler {
     }
   }
 
+  /**
+   * @param {Point} point
+   * @param {PointerEvent} originalEvent
+   */
   tap(point, originalEvent) {
     if (didTapOnMainContent(originalEvent)) {
       this._doClickOrTapAction('tap', point, originalEvent);
     }
   }
 
+  /**
+   * @param {Point} point
+   * @param {PointerEvent} originalEvent
+   */
   doubleTap(point, originalEvent) {
     if (didTapOnMainContent(originalEvent)) {
       this._doClickOrTapAction('doubleTap', point, originalEvent);
     }
   }
 
+  /** @typedef {'imageClick' | 'bgClick' | 'tap' | 'doubleTap'} Actions */
+
+  /**
+   * @param {Actions} actionName
+   * @param {Point} point
+   * @param {PointerEvent} originalEvent
+   */
   _doClickOrTapAction(actionName, point, originalEvent) {
     const { pswp } = this.gestures;
     const { currSlide } = pswp;
-    const optionValue = pswp.options[actionName + 'Action'];
+    // eslint-disable-next-line max-len
+    const optionValue = pswp.options[/** @type {AddPostfix<Actions, 'Action'>} */ (actionName + 'Action')];
 
     if (pswp.dispatch(actionName + 'Action', { point, originalEvent }).defaultPrevented) {
       return;

--- a/src/js/gestures/tap-handler.js
+++ b/src/js/gestures/tap-handler.js
@@ -2,7 +2,12 @@
  * Tap, double-tap handler.
  */
 
-/** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
+/**
+ * @template T
+ * @template P
+ * @typedef {import("../types").AddPostfix<T, P>} AddPostfix<T, P>
+ */
+
 /** @typedef {import("./gestures").default} Gestures */
 
 /** @typedef {{ x?: number; y?: number }} Point */

--- a/src/js/gestures/tap-handler.js
+++ b/src/js/gestures/tap-handler.js
@@ -1,8 +1,4 @@
 /**
- * Tap, double-tap handler.
- */
-
-/**
  * @template T
  * @template P
  * @typedef {import("../types").AddPostfix<T, P>} AddPostfix<T, P>
@@ -23,6 +19,9 @@ function didTapOnMainContent(event) {
   return !!(/** @type {HTMLElement} */ (event.target).closest('.pswp__container'));
 }
 
+/**
+ * Tap, double-tap handler.
+ */
 class TapHandler {
   /**
    * @param {Gestures} gestures

--- a/src/js/gestures/tap-handler.js
+++ b/src/js/gestures/tap-handler.js
@@ -10,6 +10,7 @@
 
 /** @typedef {import("./gestures").default} Gestures */
 
+/** @typedef {'imageClick' | 'bgClick' | 'tap' | 'doubleTap'} Actions */
 /** @typedef {{ x?: number; y?: number }} Point */
 
 /**
@@ -66,8 +67,6 @@ class TapHandler {
       this._doClickOrTapAction('doubleTap', point, originalEvent);
     }
   }
-
-  /** @typedef {'imageClick' | 'bgClick' | 'tap' | 'doubleTap'} Actions */
 
   /**
    * @param {Actions} actionName

--- a/src/js/gestures/zoom-handler.js
+++ b/src/js/gestures/zoom-handler.js
@@ -2,6 +2,9 @@ import {
   equalizePoints, getDistanceBetween, clamp, pointsEqual
 } from '../util/util.js';
 
+/** @typedef {import("../photoswipe").Point} Point */
+/** @typedef {import("./gestures").default} Gestures */
+
 const UPPER_ZOOM_FRICTION = 0.05;
 const LOWER_ZOOM_FRICTION = 0.15;
 
@@ -20,12 +23,18 @@ function getZoomPointsCenter(p, p1, p2) {
 }
 
 class ZoomHandler {
+  /**
+   * @param {Gestures} gestures
+   */
   constructor(gestures) {
     this.gestures = gestures;
     this.pswp = this.gestures.pswp;
+    /** @type {Point} */
     this._startPan = {};
 
+    /** @type {Point} */
     this._startZoomPoint = {};
+    /** @type {Point} */
     this._zoomPoint = {};
   }
 
@@ -95,6 +104,11 @@ class ZoomHandler {
     }
   }
 
+  /**
+   * @private
+   * @param {'x' | 'y'} axis
+   * @param {number} currZoomLevel
+   */
   _calculatePanForZoomLevel(axis, currZoomLevel) {
     const zoomFactor = currZoomLevel / this._startZoomLevel;
     return this._zoomPoint[axis]
@@ -106,8 +120,8 @@ class ZoomHandler {
    * beyond minimum or maximum values.
    * With animation.
    *
-   * @param {Boolean} ignoreGesture Wether gesture coordinates should be ignored
-   *                                when calculating destination pan position.
+   * @param {boolean=} ignoreGesture
+   * Wether gesture coordinates should be ignored when calculating destination pan position.
    */
   correctZoomPan(ignoreGesture) {
     const { pswp } = this;
@@ -123,6 +137,7 @@ class ZoomHandler {
 
     const prevZoomLevel = currSlide.currZoomLevel;
 
+    /** @type {number} */
     let destinationZoomLevel;
     let currZoomLevelNeedsChange = true;
 

--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -1,12 +1,3 @@
-/**
- *
- * keyboard.js
- *
- * - Manages keyboard shortcuts.
- * - Heps trap focus within photoswipe.
- *
- */
-
 import { specialKeyUsed } from './util/util.js';
 
 /** @typedef {import("./photoswipe").default} PhotoSwipe */
@@ -16,6 +7,10 @@ import { specialKeyUsed } from './util/util.js';
  * @typedef {import("./types").Methods<T>} Methods<T>
  */
 
+/**
+ * - Manages keyboard shortcuts.
+ * - Heps trap focus within photoswipe.
+ */
 class Keyboard {
   /**
    * @param {PhotoSwipe} pswp

--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -9,7 +9,12 @@
 
 import { specialKeyUsed } from './util/util.js';
 
+/** @typedef {import("./photoswipe").default} PhotoSwipe */
+
 class Keyboard {
+  /**
+   * @param {PhotoSwipe} pswp
+   */
   constructor(pswp) {
     this.pswp = pswp;
 
@@ -26,7 +31,7 @@ class Keyboard {
       pswp.events.add(document, 'keydown', this._onKeyDown.bind(this));
     });
 
-    const lastActiveElement = document.activeElement;
+    const lastActiveElement = /** @type {HTMLElement} */ (document.activeElement);
     pswp.on('destroy', () => {
       if (pswp.options.returnFocus
           && lastActiveElement
@@ -43,6 +48,9 @@ class Keyboard {
     }
   }
 
+  /**
+   * @param {KeyboardEvent} e
+   */
   _onKeyDown(e) {
     const { pswp } = this;
 
@@ -57,7 +65,9 @@ class Keyboard {
       return;
     }
 
+    /** @type {Methods<PhotoSwipe>} */
     let keydownAction;
+    /** @type {'x' | 'y'} */
     let axis;
     let isForward;
 
@@ -120,13 +130,13 @@ class Keyboard {
   /**
    * Trap focus inside photoswipe
    *
-   * @param {Event} e
+   * @param {FocusEvent} e
    */
   _onFocusIn(e) {
     const { template } = this.pswp;
     if (document !== e.target
         && template !== e.target
-        && !template.contains(e.target)) {
+        && !template.contains(/** @type {Node} */ (e.target))) {
       // focus root element
       template.focus();
     }

--- a/src/js/keyboard.js
+++ b/src/js/keyboard.js
@@ -11,6 +11,11 @@ import { specialKeyUsed } from './util/util.js';
 
 /** @typedef {import("./photoswipe").default} PhotoSwipe */
 
+/**
+ * @template T
+ * @typedef {import("./types").Methods<T>} Methods<T>
+ */
+
 class Keyboard {
   /**
    * @param {PhotoSwipe} pswp

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -1,19 +1,3 @@
-/**
- * PhotoSwipe lightbox
- *
- * - If user has unsupported browser it falls back to default browser action (just opens URL)
- * - Binds click event to links that should open PhotoSwipe
- * - parses DOM strcture for PhotoSwipe (retrieves large image URLs and sizes)
- * - Initializes PhotoSwipe
- *
- *
- * Loader options use the same object as PhotoSwipe, and supports such options:
- *
- * gallery - Element | Element[] | NodeList | string selector for the gallery element
- * children - Element | Element[] | NodeList | string selector for the gallery children
- *
- */
-
 import {
   specialKeyUsed,
   getElementsFromOption,
@@ -40,6 +24,21 @@ import { lazyLoadSlide } from '../slide/loader.js';
  * @typedef {import("../core/eventable").EventCallback<T>} EventCallback<T>
  */
 
+/**
+ * PhotoSwipe Lightbox
+ *
+ * - If user has unsupported browser it falls back to default browser action (just opens URL)
+ * - Binds click event to links that should open PhotoSwipe
+ * - parses DOM strcture for PhotoSwipe (retrieves large image URLs and sizes)
+ * - Initializes PhotoSwipe
+ *
+ *
+ * Loader options use the same object as PhotoSwipe, and supports such options:
+ *
+ * gallery - Element | Element[] | NodeList | string selector for the gallery element
+ * children - Element | Element[] | NodeList | string selector for the gallery children
+ *
+ */
 class PhotoSwipeLightbox extends PhotoSwipeBase {
   /**
    * @param {PhotoSwipeOptions} options
@@ -51,6 +50,10 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     this._uid = 0;
   }
 
+  /**
+   * Initialize lightbox, should be called only once.
+   * It's not included in the main constructor, so you may bind events before it.
+   */
   init() {
     this.onThumbnailsClick = this.onThumbnailsClick.bind(this);
 
@@ -265,6 +268,9 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     pswp.init();
   }
 
+  /**
+   * Unbinds all events, closes PhotoSwipe if it's open.
+   */
   destroy() {
     if (this.pswp) {
       this.pswp.destroy();

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -23,7 +23,12 @@ import {
 import PhotoSwipeBase from '../core/base.js';
 import { lazyLoadSlide } from '../slide/loader.js';
 
+/** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
+
 class PhotoSwipeLightbox extends PhotoSwipeBase {
+  /**
+   * @param {PhotoSwipeOptions} options
+   */
   constructor(options) {
     super();
     this.options = options || {};

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -127,7 +127,7 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
    * Load and open PhotoSwipe
    *
    * @param {number} index
-   * @param {PhotoSwipeOptions['dataSource']} dataSource
+   * @param {PhotoSwipeOptions['dataSource']} [dataSource]
    * @param {{ x?: number; y?: number }} [initialPoint]
    */
   loadAndOpen(index, dataSource, initialPoint) {

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -23,6 +23,11 @@ import {
 import PhotoSwipeBase from '../core/base.js';
 import { lazyLoadSlide } from '../slide/loader.js';
 
+/**
+ * @template T
+ * @typedef {import("../types").Type<T>} Type<T>
+ */
+
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
 /** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
 /** @typedef {import("../slide/content").default} Content */
@@ -33,7 +38,7 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
    */
   constructor(options) {
     super();
-    /** @type {Partial<PhotoSwipeOptions>} */
+    /** @type {PhotoSwipeOptions} */
     this.options = options || {};
     this._uid = 0;
   }
@@ -155,16 +160,16 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
 
     // Add the main module
     // PhotoSwipeOptions['pswpModule'][]
-    /** @type {Promise<PhotoSwipe>[]} */
+    /** @type {Promise<Type<PhotoSwipe>>[]} */
     const promiseArray = [];
 
     const pswpModuleType = typeof options.pswpModule;
     if (isPswpClass(options.pswpModule)) {
-      promiseArray.push(/** @type {Promise<PhotoSwipe>} */ (options.pswpModule));
+      promiseArray.push(Promise.resolve(/** @type {Type<PhotoSwipe>} */ (options.pswpModule)));
     } else if (pswpModuleType === 'string') {
       throw new Error('pswpModule as string is no longer supported');
     } else if (pswpModuleType === 'function') {
-      promiseArray.push(/** @type {() => Promise<PhotoSwipe>} */ (options.pswpModule)());
+      promiseArray.push(/** @type {() => Promise<Type<PhotoSwipe>>} */ (options.pswpModule)());
     } else {
       throw new Error('pswpModule is not valid');
     }
@@ -193,7 +198,7 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
 
   /**
    * @private
-   * @param {PhotoSwipe | { default: PhotoSwipe }} module
+   * @param {Type<PhotoSwipe> | { default: Type<PhotoSwipe> }} module
    * @param {number} uid
    */
   _openPhotoswipe(module, uid) {
@@ -219,9 +224,7 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
      * @type {PhotoSwipe}
      */
     const pswp = typeof module === 'object'
-    // @ts-expect-error
         ? new module.default(this.options) // eslint-disable-line
-    // @ts-expect-error
         : new module(this.options); // eslint-disable-line
 
     this.pswp = pswp;

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -31,6 +31,8 @@ import { lazyLoadSlide } from '../slide/loader.js';
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
 /** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
 /** @typedef {import("../slide/content").default} Content */
+/** @typedef {import("../core/eventable").PhotoSwipeEventsMap} PhotoSwipeEventsMap */
+/** @typedef {import("../core/eventable").PhotoSwipeFiltersMap} PhotoSwipeFiltersMap */
 
 class PhotoSwipeLightbox extends PhotoSwipeBase {
   /**
@@ -230,15 +232,24 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     this.pswp = pswp;
     window.pswp = pswp;
 
-    // map listeners from Lightbox to PhotoSwipe Core
-    Object.keys(this._listeners).forEach((name) => {
+    /**
+     * map listeners from Lightbox to PhotoSwipe Core
+     *
+     * @type {(keyof PhotoSwipeEventsMap)[]}
+     */
+    (Object.keys(this._listeners)).forEach((name) => {
       this._listeners[name].forEach((fn) => {
+        // @ts-expect-error TODO: weird things
         pswp.on(name, fn);
       });
     });
 
-    // same with filters
-    Object.keys(this._filters).forEach((name) => {
+    /**
+     * same with filters
+     *
+     * @type {(keyof PhotoSwipeFiltersMap)[]}
+     */
+    (Object.keys(this._filters)).forEach((name) => {
       this._filters[name].forEach((filter) => {
         pswp.addFilter(name, filter.fn, filter.priority);
       });

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -35,6 +35,11 @@ import { lazyLoadSlide } from '../slide/loader.js';
 /** @typedef {import("../core/eventable").PhotoSwipeEventsMap} PhotoSwipeEventsMap */
 /** @typedef {import("../core/eventable").PhotoSwipeFiltersMap} PhotoSwipeFiltersMap */
 
+/**
+ * @template T
+ * @typedef {import("../core/eventable").EventCallback<T>} EventCallback<T>
+ */
+
 class PhotoSwipeLightbox extends PhotoSwipeBase {
   /**
    * @param {PhotoSwipeOptions} options
@@ -230,23 +235,16 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     this.pswp = pswp;
     window.pswp = pswp;
 
-    /**
-     * map listeners from Lightbox to PhotoSwipe Core
-     *
-     * @type {(keyof PhotoSwipeEventsMap)[]}
-     */
+    // map listeners from Lightbox to PhotoSwipe Core
+    /** @type {(keyof PhotoSwipeEventsMap)[]} */
     (Object.keys(this._listeners)).forEach((name) => {
       this._listeners[name].forEach((fn) => {
-        // @ts-expect-error TODO: weird things
-        pswp.on(name, fn);
+        pswp.on(name, /** @type {EventCallback<typeof name>} */(fn));
       });
     });
 
-    /**
-     * same with filters
-     *
-     * @type {(keyof PhotoSwipeFiltersMap)[]}
-     */
+    // same with filters
+    /** @type {(keyof PhotoSwipeFiltersMap)[]} */
     (Object.keys(this._filters)).forEach((name) => {
       this._filters[name].forEach((filter) => {
         pswp.addFilter(name, filter.fn, filter.priority);

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -30,6 +30,7 @@ import { lazyLoadSlide } from '../slide/loader.js';
 
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
 /** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
+/** @typedef {import("../photoswipe").DataSource} DataSource */
 /** @typedef {import("../slide/content").default} Content */
 /** @typedef {import("../core/eventable").PhotoSwipeEventsMap} PhotoSwipeEventsMap */
 /** @typedef {import("../core/eventable").PhotoSwipeFiltersMap} PhotoSwipeFiltersMap */
@@ -127,7 +128,7 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
    * Load and open PhotoSwipe
    *
    * @param {number} index
-   * @param {PhotoSwipeOptions['dataSource']} [dataSource]
+   * @param {DataSource=} dataSource
    * @param {{ x?: number; y?: number }} [initialPoint]
    */
   loadAndOpen(index, dataSource, initialPoint) {
@@ -151,7 +152,7 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
    * Load the main module and the slide content by index
    *
    * @param {number} index
-   * @param {PhotoSwipeOptions['dataSource']} dataSource
+   * @param {DataSource=} dataSource
    */
   preload(index, dataSource) {
     const { options } = this;

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -162,7 +162,6 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     }
 
     // Add the main module
-    // PhotoSwipeOptions['pswpModule'][]
     /** @type {Promise<Type<PhotoSwipe>>[]} */
     const promiseArray = [];
 
@@ -184,8 +183,6 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
     }
 
     if (options.preloadFirstSlide !== false && index >= 0) {
-      /** @type {Content} */
-      // @ts-expect-error
       this._preloadedContent = lazyLoadSlide(index, this);
     }
 

--- a/src/js/main-scroll.js
+++ b/src/js/main-scroll.js
@@ -12,6 +12,8 @@ import {
 /** @typedef {import("./photoswipe").default} PhotoSwipe */
 /** @typedef {import("./slide/slide").default} Slide */
 
+/** @typedef {{ el: HTMLDivElement; slide?: Slide }} ItemHolder */
+
 const MAIN_SCROLL_END_FRICTION = 0.35;
 
 
@@ -23,7 +25,7 @@ class MainScroll {
   /** @type {number} */
   slideWidth;
 
-  /** @type {{ el: HTMLDivElement; slide?: Slide }[]} */
+  /** @type {ItemHolder[]} */
   itemHolders;
 
   /**

--- a/src/js/main-scroll.js
+++ b/src/js/main-scroll.js
@@ -9,6 +9,9 @@ import {
   createElement,
 } from './util/util.js';
 
+/** @typedef {import("./photoswipe").default} PhotoSwipe */
+/** @typedef {import("./slide/slide").default} Slide */
+
 const MAIN_SCROLL_END_FRICTION = 0.35;
 
 
@@ -17,6 +20,12 @@ const MAIN_SCROLL_END_FRICTION = 0.35;
 // const DEFAULT_SWIPE_TRANSITION_DURATION = 333;
 
 class MainScroll {
+  /** @type {number} */
+  slideWidth;
+
+  /** @type {{ el: HTMLDivElement; slide?: Slide }[]} */
+  itemHolders;
+
   /**
    * @param {PhotoSwipe} pswp
    */
@@ -115,8 +124,10 @@ class MainScroll {
    * If loop option is enabled - index will be automatically looped too,
    * (for example `-1` will move to the last slide of the gallery).
    *
-   * @param {Integer} diff
-   * @returns {Boolean} whether index was changed or not
+   * @param {number} diff
+   * @param {boolean=} animate
+   * @param {number=} velocityX
+   * @returns {boolean} whether index was changed or not
    */
   moveIndexBy(diff, animate, velocityX) {
     const { pswp } = this;
@@ -284,11 +295,13 @@ class MainScroll {
   /**
    * Move the X position of the main scroll container
    *
-   * @param {Number} x
-   * @param {Boolean} dragging
+   * @param {number} x
+   * @param {boolean=} dragging
    */
   moveTo(x, dragging) {
+    /** @type {number} */
     let newSlideIndexOffset;
+    /** @type {number} */
     let delta;
 
     if (!this.pswp.canLoop() && dragging) {

--- a/src/js/main-scroll.js
+++ b/src/js/main-scroll.js
@@ -1,9 +1,3 @@
-/**
- * Handles movement of the main scrolling container
- * (for example, it repositions when user swipes left or right).
- *
- * Also stores its state.
- */
 import {
   setTransform,
   createElement,
@@ -21,6 +15,12 @@ const MAIN_SCROLL_END_FRICTION = 0.35;
 // const MAX_SWIPE_TRABSITION_DURATION = 500;
 // const DEFAULT_SWIPE_TRANSITION_DURATION = 333;
 
+/**
+ * Handles movement of the main scrolling container
+ * (for example, it repositions when user swipes left or right).
+ *
+ * Also stores its state.
+ */
 class MainScroll {
   /** @type {number} */
   slideWidth;

--- a/src/js/main-scroll.js
+++ b/src/js/main-scroll.js
@@ -31,7 +31,7 @@ class MainScroll {
    * Position the scroller and slide containers
    * according to viewport size.
    *
-   * @param {Boolean} resizeSlides Whether slides content should resized
+   * @param {boolean=} resizeSlides Whether slides content should resized
    */
   resize(resizeSlides) {
     const { pswp } = this;

--- a/src/js/opener.js
+++ b/src/js/opener.js
@@ -229,7 +229,10 @@ class Opener {
     );
 
     // legacy event
-    this.pswp.dispatch('initialZoom' + (this.isOpening ? 'In' : 'Out'));
+    this.pswp.dispatch(
+      /** @type {'initialZoomIn' | 'initialZoomOut'} */
+      ('initialZoom' + (this.isOpening ? 'In' : 'Out'))
+    );
 
     this.pswp.element.classList[this.isOpening ? 'add' : 'remove']('pswp--ui-visible');
 
@@ -260,7 +263,10 @@ class Opener {
     );
 
     // legacy event
-    pswp.dispatch('initialZoom' + (this.isOpen ? 'InEnd' : 'OutEnd'));
+    pswp.dispatch(
+      /** @type {'initialZoomInEnd' | 'initialZoomOutEnd'} */
+      ('initialZoom' + (this.isOpen ? 'InEnd' : 'OutEnd'))
+    );
 
     if (this.isClosed) {
       pswp.destroy();

--- a/src/js/opener.js
+++ b/src/js/opener.js
@@ -1,9 +1,3 @@
-/**
- * Manages opening and closing transitions of the PhotoSwipe.
- *
- * It can perform zoom, fade or no transition.
- */
-
 import {
   setTransform,
   equalizePoints,
@@ -21,6 +15,11 @@ import {
 // we set it to the minimum amount
 const MIN_OPACITY = 0.003;
 
+/**
+ * Manages opening and closing transitions of the PhotoSwipe.
+ *
+ * It can perform zoom, fade or no transition.
+ */
 class Opener {
   /** @type {false | Bounds} */
   _thumbBounds;

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -34,6 +34,7 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {{ top: number; bottom: number; left: number; right: number }} Padding */
 /** @typedef {SlideData[]} DataSourceArray */
 /** @typedef {{ gallery: HTMLElement; items?: HTMLElement[] }} DataSourceObject */
+/** @typedef {DataSourceArray | DataSourceObject} DataSource */
 /** @typedef {(point: Point, originalEvent: PointerEvent) => void} ActionFn */
 /** @typedef {'close' | 'next' | 'zoom' | 'zoom-or-close' | 'toggle-controls'} ActionType */
 
@@ -44,7 +45,7 @@ import ContentLoader from './slide/loader.js';
 /**
  * @typedef {Object} PhotoSwipeOptions
  *
- * @prop {DataSourceArray | DataSourceObject} [dataSource]
+ * @prop {DataSource} [dataSource]
  * Pass an array of any items via dataSource option. Its length will determine amount of slides
  * (which may be modified further from numItems event).
  *
@@ -331,7 +332,7 @@ class PhotoSwipe extends PhotoSwipeBase {
     this.offset.y = window.pageYOffset;
 
     this._initialItemData = this.getItemData(this.currIndex);
-    // @ts-expect-error TODO
+    // @ts-expect-error Expected 1-2 arguments, but got 4 ¯\_(ツ)_/¯
     this.dispatch('gettingData', this.currIndex, this._initialItemData, true);
 
     // *Layout* - calculate size and position of elements here

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -32,6 +32,7 @@ import ContentLoader from './slide/loader.js';
 
 /** @typedef {(point: Point, originalEvent: PointerEvent) => void} ActionFn */
 /** @typedef {'close' | 'next' | 'zoom' | 'zoom-or-close' | 'toggle-controls'} ActionType */
+/** @typedef {import("./ui/ui-element").UIElementData} UIElementData */
 
 /**
  * @typedef {Object} PhotoSwipeOptions

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -20,24 +20,31 @@ import PhotoSwipeBase from './core/base.js';
 import Opener from './opener.js';
 import ContentLoader from './slide/loader.js';
 
+/**
+ * @template T
+ * @typedef {import("./types").Type<T>} Type<T>
+ */
+
 /** @typedef {import("./slide/slide").SlideData} SlideData */
 /** @typedef {import("./slide/zoom-level").ZoomLevelOption} ZoomLevelOption */
-/** @typedef {any} PhotoSwipeLightbox TODO */
+/** @typedef {import("./ui/ui-element").UIElementData} UIElementData */
+
 /** @typedef {{ x?: number; y?: number; id?: string | number }} Point */
 /** @typedef {{ x?: number; y?: number }} Size */
 /** @typedef {{ top: number; bottom: number; left: number; right: number }} Padding */
-
 /** @typedef {SlideData[]} DataSourceArray */
 /** @typedef {{ gallery: HTMLElement; items?: HTMLElement[] }} DataSourceObject */
-
 /** @typedef {(point: Point, originalEvent: PointerEvent) => void} ActionFn */
 /** @typedef {'close' | 'next' | 'zoom' | 'zoom-or-close' | 'toggle-controls'} ActionType */
-/** @typedef {import("./ui/ui-element").UIElementData} UIElementData */
+
+/** @typedef {Type<PhotoSwipe> | { default: Type<PhotoSwipe> }} PhotoSwipeModule */
+// eslint-disable-next-line max-len
+/** @typedef {PhotoSwipeModule | Promise<PhotoSwipeModule> | (() => Promise<PhotoSwipeModule>)} PhotoSwipeModuleOption */
 
 /**
  * @typedef {Object} PhotoSwipeOptions
  *
- * @prop {DataSourceArray | DataSourceObject} dataSource
+ * @prop {DataSourceArray | DataSourceObject} [dataSource]
  * Pass an array of any items via dataSource option. Its length will determine amount of slides
  * (which may be modified further from numItems event).
  *
@@ -188,7 +195,7 @@ import ContentLoader from './slide/loader.js';
  * @prop {Point | null} [initialPointerPos]
  * @prop {boolean=} showHideOpacity
  *
- * @prop {Promise<PhotoSwipe> | (() => Promise<PhotoSwipe>)} [pswpModule]
+ * @prop {PhotoSwipeModuleOption} [pswpModule]
  * @prop {() => Promise<any>} [openPromise]
  * @prop {boolean=} preloadFirstSlide
  * @prop {string=} gallery
@@ -198,7 +205,7 @@ import ContentLoader from './slide/loader.js';
  * @prop {string | false} [thumbSelector]
  */
 
-/** @type {Partial<PhotoSwipeOptions>} */
+/** @type {PhotoSwipeOptions} */
 const defaultOptions = {
   allowPanToNext: true,
   spacing: 0.1,

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -29,6 +29,16 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {import("./slide/zoom-level").ZoomLevelOption} ZoomLevelOption */
 /** @typedef {import("./ui/ui-element").UIElementData} UIElementData */
 /** @typedef {import("./main-scroll").ItemHolder} ItemHolder */
+/** @typedef {import("./core/eventable").PhotoSwipeEventsMap} PhotoSwipeEventsMap */
+/** @typedef {import("./core/eventable").PhotoSwipeFiltersMap} PhotoSwipeFiltersMap */
+/**
+ * @template T
+ * @typedef {import("./core/eventable").EventCallback<T>} EventCallback<T>
+ */
+/**
+ * @template T
+ * @typedef {import("./core/eventable").AugmentedEvent<T>} AugmentedEvent<T>
+ */
 
 /** @typedef {{ x?: number; y?: number; id?: string | number }} Point */
 /** @typedef {{ x?: number; y?: number }} Size */

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -37,15 +37,13 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {DataSourceArray | DataSourceObject} DataSource */
 /** @typedef {(point: Point, originalEvent: PointerEvent) => void} ActionFn */
 /** @typedef {'close' | 'next' | 'zoom' | 'zoom-or-close' | 'toggle-controls'} ActionType */
-
 /** @typedef {Type<PhotoSwipe> | { default: Type<PhotoSwipe> }} PhotoSwipeModule */
-// eslint-disable-next-line max-len
 /** @typedef {PhotoSwipeModule | Promise<PhotoSwipeModule> | (() => Promise<PhotoSwipeModule>)} PhotoSwipeModuleOption */
 
 /**
- * @typedef {Object} PhotoSwipeOptions
+ * @typedef {Object} PhotoSwipeOptions https://photoswipe.com/options/
  *
- * @prop {DataSource} [dataSource]
+ * @prop {DataSource=} dataSource
  * Pass an array of any items via dataSource option. Its length will determine amount of slides
  * (which may be modified further from numItems event).
  *

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -23,12 +23,15 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {import("./slide/slide").SlideData} SlideData */
 /** @typedef {import("./slide/zoom-level").ZoomLevelOption} ZoomLevelOption */
 /** @typedef {any} PhotoSwipeLightbox TODO */
-/** @typedef {{ x?: number; y?: number; id?: string }} Point */
+/** @typedef {{ x?: number; y?: number; id?: string | number }} Point */
 /** @typedef {{ x?: number; y?: number }} Size */
 /** @typedef {{ top: number; bottom: number; left: number; right: number }} Padding */
 
 /** @typedef {SlideData[]} DataSourceArray */
 /** @typedef {{ gallery: HTMLElement; items?: HTMLElement[] }} DataSourceObject */
+
+/** @typedef {(point: Point, originalEvent: PointerEvent) => void} ActionFn */
+/** @typedef {'close' | 'next' | 'zoom' | 'zoom-or-close' | 'toggle-controls'} ActionType */
 
 /**
  * @typedef {Object} PhotoSwipeOptions
@@ -94,16 +97,16 @@ import ContentLoader from './slide/loader.js';
  * @prop {boolean=} clickToCloseNonZoomable
  * If image is not zoomable (for example, smaller than viewport) it can be closed by clicking on it.
  *
- * @prop {string=} imageClickAction
+ * @prop {ActionType | ActionFn} [imageClickAction]
  * Refer to click and tap actions page.
  *
- * @prop {string=} bgClickAction
+ * @prop {ActionType | ActionFn} [bgClickAction]
  * Refer to click and tap actions page.
  *
- * @prop {string=} tapAction
+ * @prop {ActionType | ActionFn} [tapAction]
  * Refer to click and tap actions page.
  *
- * @prop {string=} doubleTapAction
+ * @prop {ActionType | ActionFn} [doubleTapAction]
  * Refer to click and tap actions page.
  *
  * @prop {number=} preloaderDelay

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -20,6 +20,90 @@ import PhotoSwipeBase from './core/base.js';
 import Opener from './opener.js';
 import ContentLoader from './slide/loader.js';
 
+/** @typedef {any} PhotoSwipeLightbox TODO */
+/** @typedef {'fit' | 'fill' | number | ((zoomLevelObject: any) => any)} ZoomLevel TODO */
+/** @typedef {{ x?: number; y?: number; id?: string }} Point */
+/** @typedef {{ x: number; y: number }} Size */
+/** @typedef {{ top: number; bottom: number; left: number; right: number }} Padding */
+
+/**
+ * @typedef {Object} PhotoSwipeOptions
+ *
+ * @prop {PhotoSwipeItem[]} dataSource
+ * @prop {boolean=} allowPanToNext
+ * @prop {number=} spacing
+ * @prop {boolean=} loop
+ * @prop {boolean=} pinchToClose
+ * @prop {boolean=} closeOnVerticalDrag
+ * @prop {Padding=} padding
+ * @prop {(viewportSize: Size, itemData: PhotoSwipeItem, index: number) => Padding} [paddingFn]
+ * @prop {number=} hideAnimationDuration
+ * @prop {number=} showAnimationDuration
+ * @prop {number=} zoomAnimationDuration
+ * @prop {'zoom' | 'fade' | 'none'} [showHideAnimationType]
+ * @prop {boolean=} escKey
+ * @prop {boolean=} arrowKeys
+ * @prop {boolean=} returnFocus
+ * @prop {number=} maxWidthToAnimate
+ * @prop {boolean=} clickToCloseNonZoomable
+ * @prop {string=} imageClickAction
+ * @prop {string=} bgClickAction
+ * @prop {string=} tapAction
+ * @prop {string=} doubleTapAction
+ * @prop {string=} indexIndicatorSep
+ * @prop {number=} preloaderDelay
+ * @prop {number=} panPaddingRatio
+ * @prop {number=} bgOpacity
+ * @prop {number=} index
+ * @prop {string=} errorMsg
+ * @prop {[number, number]=} preload
+ * @prop {string=} easing
+ * @prop {number=} paddingTop
+ * @prop {number=} paddingBottom
+ * @prop {number=} paddingLeft
+ * @prop {number=} paddingRight
+ * @prop {string=} gallerySelector
+ * @prop {string=} childSelector
+ * @prop {(pswp: PhotoSwipeLightbox, e: Event) => number} [getClickedIndexFn]
+ * @prop {string=} arrowPrevSVG
+ * @prop {string=} arrowNextSVG
+ * @prop {string=} mainClass
+ * @prop {string=} closeTitle
+ * @prop {string=} zoomTitle
+ * @prop {string=} arrowPrevTitle
+ * @prop {string=} arrowNextTitle
+ * @prop {boolean=} arrowPrev
+ * @prop {boolean=} arrowNext
+ * @prop {boolean=} zoom
+ * @prop {boolean=} close
+ * @prop {boolean=} counter
+ * @prop {ZoomLevel=} initialZoomLevel
+ * @prop {ZoomLevel=} secondaryZoomLevel
+ * @prop {ZoomLevel=} maxZoomLevel
+ * @prop {boolean=} mouseMovePan
+ * @prop {Promise<any>} [openPromise] // TODO
+ * @prop {HTMLElement=} appendToEl
+ * @prop {Point | null} [initialPointerPos]
+ * @prop {(options: PhotoSwipeOptions, pswp: PhotoSwipe) => { x: number; y: number }} [getViewportSizeFn]
+ */
+
+/**
+ * @typedef {_PhotoSwipeItemProps & Record<string, any>} PhotoSwipeItem
+ * @typedef {Object} _PhotoSwipeItemProps
+ * @prop {HTMLElement=} element
+ * @prop {string=} src
+ * @prop {string=} srcset
+ * @prop {number=} w
+ * @prop {number=} h
+ * @prop {string=} msrc
+ * @prop {string=} alt
+ * @prop {boolean=} thumbCropped
+ * @prop {string=} html
+ * @prop {'image' | 'html'} [type]
+ * @prop {'image' | 'html'} [type]
+ */
+
+/** @type {Partial<PhotoSwipeOptions>} */
 const defaultOptions = {
   allowPanToNext: true,
   spacing: 0.1,
@@ -49,20 +133,39 @@ const defaultOptions = {
 };
 
 class PhotoSwipe extends PhotoSwipeBase {
+  /**
+   * @param {PhotoSwipeOptions} options
+   */
   constructor(options) {
     super();
 
     this._prepareOptions(options);
 
-    // offset of viewport relative to document
+    /**
+     * offset of viewport relative to document
+     *
+     * @type {{ x?: number; y?: number }}
+     */
     this.offset = {};
 
+    /**
+     * @type {{ x?: number; y?: number }}
+     * @private
+     */
     this._prevViewportSize = {};
 
-    // Size of scrollable PhotoSwipe viewport
+    /**
+     * Size of scrollable PhotoSwipe viewport
+     *
+     * @type {{ x?: number; y?: number }}
+     */
     this.viewportSize = {};
 
-    // background (backdrop) opacity
+    /**
+     * background (backdrop) opacity
+     *
+     * @type {number}
+     */
     this.bgOpacity = 1;
 
     this.events = new DOMEvents();
@@ -123,6 +226,7 @@ class PhotoSwipe extends PhotoSwipeBase {
     this.offset.y = window.pageYOffset;
 
     this._initialItemData = this.getItemData(this.currIndex);
+    // @ts-expect-error TODO
     this.dispatch('gettingData', this.currIndex, this._initialItemData, true);
 
     // *Layout* - calculate size and position of elements here
@@ -161,7 +265,7 @@ class PhotoSwipe extends PhotoSwipeBase {
    * Get looped slide index
    * (for example, -1 will return the last slide)
    *
-   * @param {Integer} index
+   * @param {number} index
    */
   getLoopedIndex(index) {
     const numSlides = this.getNumItems();
@@ -191,7 +295,7 @@ class PhotoSwipe extends PhotoSwipeBase {
 
   /**
    * Change the slide
-   * @param  {Integer} New index
+   * @param  {number} index New index
    */
   goTo(index) {
     this.mainScroll.moveIndexBy(
@@ -215,6 +319,9 @@ class PhotoSwipe extends PhotoSwipeBase {
 
   /**
    * @see slide/slide.js zoomTo
+   * TODO
+   *
+   * @param {any[]} args
    */
   zoomTo(...args) {
     this.currSlide.zoomTo(...args);
@@ -280,7 +387,7 @@ class PhotoSwipe extends PhotoSwipeBase {
   /**
    * Refresh/reload content of a slide by its index
    *
-   * @param {Integer} slideIndex
+   * @param {number} slideIndex
    */
   refreshSlideContent(slideIndex) {
     this.contentLoader.removeByIndex(slideIndex);
@@ -308,9 +415,9 @@ class PhotoSwipe extends PhotoSwipeBase {
   /**
    * Set slide content
    *
-   * @param {Object} holder mainScroll.itemHolders array item
-   * @param {Integer} index Slide index
-   * @param {Boolean} force If content should be set even if index wasn't changed
+   * @param {Record<string, any>} holder TODO mainScroll.itemHolders array item
+   * @param {number} index Slide index
+   * @param {boolean=} force If content should be set even if index wasn't changed
    */
   setContent(holder, index, force) {
     if (this.canLoop()) {
@@ -356,7 +463,7 @@ class PhotoSwipe extends PhotoSwipeBase {
    * Update size of all elements.
    * Executed on init and on page resize.
    *
-   * @param  {Boolean} force Update size even if size of viewport was not changed.
+   * @param {boolean=} force Update size even if size of viewport was not changed.
    */
   updateSize(force) {
     // let item;
@@ -401,9 +508,12 @@ class PhotoSwipe extends PhotoSwipeBase {
     this.dispatch('resize');
   }
 
+  /**
+   * @param {number} opacity
+   */
   applyBgOpacity(opacity) {
     this.bgOpacity = Math.max(opacity, 0);
-    this.bg.style.opacity = this.bgOpacity * this.options.bgOpacity;
+    this.bg.style.opacity = String(this.bgOpacity * this.options.bgOpacity);
   }
 
   /**
@@ -418,6 +528,8 @@ class PhotoSwipe extends PhotoSwipeBase {
 
   /**
    * Page resize event handler
+   *
+   * @private
    */
   _handlePageResize() {
     this.updateSize();
@@ -438,11 +550,17 @@ class PhotoSwipe extends PhotoSwipeBase {
    * Page scroll offset is used
    * to get correct coordinates
    * relative to PhotoSwipe viewport.
+   *
+   * @private
    */
   _updatePageScrollOffset() {
     this.setScrollOffset(0, window.pageYOffset);
   }
 
+  /**
+   * @param {number} x
+   * @param {number} y
+   */
   setScrollOffset(x, y) {
     this.offset.x = x;
     this.offset.y = y;
@@ -452,11 +570,13 @@ class PhotoSwipe extends PhotoSwipeBase {
   /**
    * Create main HTML structure of PhotoSwipe,
    * and add it to DOM
+   *
+   * @private
    */
   _createMainStructure() {
     // root DOM element of PhotoSwipe (.pswp)
     this.element = createElement('pswp');
-    this.element.setAttribute('tabindex', -1);
+    this.element.setAttribute('tabindex', '-1');
     this.element.setAttribute('role', 'dialog');
 
     // template is legacy prop
@@ -500,12 +620,17 @@ class PhotoSwipe extends PhotoSwipeBase {
     return (this.options.loop && this.getNumItems() > 2);
   }
 
+  /**
+   * @param {PhotoSwipeOptions} options
+   * @private
+   */
   _prepareOptions(options) {
     if (window.matchMedia('(prefers-reduced-motion), (update: slow)').matches) {
       options.showHideAnimationType = 'none';
       options.zoomAnimationDuration = 0;
     }
 
+    /** @type {PhotoSwipeOptions}*/
     this.options = {
       ...defaultOptions,
       ...options

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -28,6 +28,7 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {import("./slide/slide").SlideData} SlideData */
 /** @typedef {import("./slide/zoom-level").ZoomLevelOption} ZoomLevelOption */
 /** @typedef {import("./ui/ui-element").UIElementData} UIElementData */
+/** @typedef {import("./main-scroll").ItemHolder} ItemHolder */
 
 /** @typedef {{ x?: number; y?: number; id?: string | number }} Point */
 /** @typedef {{ x?: number; y?: number }} Size */
@@ -519,7 +520,7 @@ class PhotoSwipe extends PhotoSwipeBase {
   /**
    * Set slide content
    *
-   * @param {Record<string, any>} holder TODO mainScroll.itemHolders array item
+   * @param {ItemHolder} holder mainScroll.itemHolders array item
    * @param {number} index Slide index
    * @param {boolean=} force If content should be set even if index wasn't changed
    */

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -20,87 +20,157 @@ import PhotoSwipeBase from './core/base.js';
 import Opener from './opener.js';
 import ContentLoader from './slide/loader.js';
 
+/** @typedef {import("./slide/slide").SlideData} SlideData */
+/** @typedef {import("./slide/zoom-level").ZoomLevelOption} ZoomLevelOption */
 /** @typedef {any} PhotoSwipeLightbox TODO */
-/** @typedef {'fit' | 'fill' | number | ((zoomLevelObject: any) => any)} ZoomLevel TODO */
 /** @typedef {{ x?: number; y?: number; id?: string }} Point */
-/** @typedef {{ x: number; y: number }} Size */
+/** @typedef {{ x?: number; y?: number }} Size */
 /** @typedef {{ top: number; bottom: number; left: number; right: number }} Padding */
 
 /**
  * @typedef {Object} PhotoSwipeOptions
  *
- * @prop {PhotoSwipeItem[]} dataSource
- * @prop {boolean=} allowPanToNext
- * @prop {number=} spacing
- * @prop {boolean=} loop
- * @prop {boolean=} pinchToClose
- * @prop {boolean=} closeOnVerticalDrag
- * @prop {Padding=} padding
- * @prop {(viewportSize: Size, itemData: PhotoSwipeItem, index: number) => Padding} [paddingFn]
- * @prop {number=} hideAnimationDuration
- * @prop {number=} showAnimationDuration
- * @prop {number=} zoomAnimationDuration
- * @prop {'zoom' | 'fade' | 'none'} [showHideAnimationType]
- * @prop {boolean=} escKey
- * @prop {boolean=} arrowKeys
- * @prop {boolean=} returnFocus
- * @prop {number=} maxWidthToAnimate
- * @prop {boolean=} clickToCloseNonZoomable
- * @prop {string=} imageClickAction
- * @prop {string=} bgClickAction
- * @prop {string=} tapAction
- * @prop {string=} doubleTapAction
- * @prop {string=} indexIndicatorSep
- * @prop {number=} preloaderDelay
- * @prop {number=} panPaddingRatio
+ * @prop {SlideData[]} dataSource
+ * Pass an array of any items via dataSource option. Its length will determine amount of slides
+ * (which may be modified further from numItems event).
+ *
+ * Each item should contain data that you need to generate slide
+ * (for image slide it would be src (image URL), width (image width), height, srcset, alt).
+ *
+ * If these properties are not present in your initial array, you may "pre-parse" each item from itemData filter.
+ *
  * @prop {number=} bgOpacity
- * @prop {number=} index
- * @prop {string=} errorMsg
- * @prop {[number, number]=} preload
+ * Background backdrop opacity, always define it via this option and not via CSS rgba color.
+ *
+ * @prop {number=} spacing
+ * Spacing between slides. Defined as ratio relative to the viewport width (0.1 = 10% of viewport).
+ *
+ * @prop {boolean=} allowPanToNext
+ * Allow swipe navigation to the next slide when the current slide is zoomed. Does not apply to mouse events.
+ *
+ * @prop {boolean=} loop
+ * If set to true you'll be able to swipe from the last to the first image.
+ * Option is always false when there are less than 3 slides.
+ *
+ * @prop {boolean=} wheelToZoom
+ * By default PhotoSwipe zooms image with ctrl-wheel, if you enable this option - image will zoom just via wheel.
+ *
+ * @prop {boolean=} pinchToClose
+ * Pinch touch gesture to close the gallery.
+ *
+ * @prop {boolean=} closeOnVerticalDrag
+ * Vertical drag gesture to close the PhotoSwipe.
+ *
+ * @prop {Padding=} padding
+ * Slide area padding (in pixels).
+ *
+ * @prop {(viewportSize: Size, itemData: SlideData, index: number) => Padding} [paddingFn]
+ * The option is checked frequently, so make sure it's performant. Overrides padding option if defined. For example:
+ *
+ * @prop {number=} hideAnimationDuration
+ * Transition duration in milliseconds, can be 0.
+ *
+ * @prop {number=} showAnimationDuration
+ * Transition duration in milliseconds, can be 0.
+ *
+ * @prop {number=} zoomAnimationDuration
+ * Transition duration in milliseconds, can be 0.
+ *
  * @prop {string=} easing
- * @prop {number=} paddingTop
- * @prop {number=} paddingBottom
- * @prop {number=} paddingLeft
- * @prop {number=} paddingRight
- * @prop {string=} gallerySelector
- * @prop {string=} childSelector
+ * String, 'cubic-bezier(.4,0,.22,1)'. CSS easing function for open/close/zoom transitions.
+ *
+ * @prop {boolean=} escKey
+ * Esc key to close.
+ *
+ * @prop {boolean=} arrowKeys
+ * Left/right arrow keys for navigation.
+ *
+ * @prop {boolean=} returnFocus
+ * Restore focus the last active element after PhotoSwipe is closed.
+ *
+ * @prop {boolean=} clickToCloseNonZoomable
+ * If image is not zoomable (for example, smaller than viewport) it can be closed by clicking on it.
+ *
+ * @prop {string=} imageClickAction
+ * Refer to click and tap actions page.
+ *
+ * @prop {string=} bgClickAction
+ * Refer to click and tap actions page.
+ *
+ * @prop {string=} tapAction
+ * Refer to click and tap actions page.
+ *
+ * @prop {string=} doubleTapAction
+ * Refer to click and tap actions page.
+ *
+ * @prop {number=} preloaderDelay
+ * Delay before the loading indicator will be displayed,
+ * if image is loaded during it - the indicator will not be displayed at all. Can be zero.
+ *
+ * @prop {string=} indexIndicatorSep
+ * Used for slide count indicator ("1 of 10 ").
+ *
+ * @prop {(options: PhotoSwipeOptions, pswp: PhotoSwipe) => { x: number; y: number }} [getViewportSizeFn]
+ * A function that should return slide viewport width and height, in format {x: 100, y: 100}.
+ *
+ * @prop {string=} errorMsg
+ * Message to display when the image wasn't able to load. If you need to display HTML - use contentErrorElement filter.
+ *
+ * @prop {[number, number]=} preload
+ * Lazy loading of nearby slides based on direction of movement. Should be an array with two integers,
+ * first one - number of items to preload before the current image, second one - after the current image.
+ * Two nearby images are always loaded.
+ *
+ * @prop {string=} mainClass
+ * Class that will be added to the root element of PhotoSwipe, may contain multiple separated by space.
+ * Example on Styling page.
+ *
+ * @prop {HTMLElement=} appendToEl
+ * Element to which PhotoSwipe dialog will be appended when it opens.
+ *
+ * @prop {number=} maxWidthToAnimate
+ * Maximum width of image to animate, if initial rendered image width
+ * is larger than this value - the opening/closing transition will be automatically disabled.
+ *
+ * @prop {string=} closeTitle
+ * Translating
+ *
+ * @prop {string=} zoomTitle
+ * Translating
+ *
+ * @prop {string=} arrowPrevTitle
+ * Translating
+ *
+ * @prop {string=} arrowNextTitle
+ * Translating
+ *
+ * @prop {'zoom' | 'fade' | 'none'} [showHideAnimationType]
+ * To adjust opening or closing transition type use lightbox option `showHideAnimationType` (`String`).
+ * It supports three values - `zoom` (default), `fade` (default if there is no thumbnail) and `none`.
+ *
+ * Animations are automatically disabled if user `(prefers-reduced-motion: reduce)`.
+ *
+ * @prop {number=} index
+ * Defines start slide index.
+ *
  * @prop {(pswp: PhotoSwipeLightbox, e: Event) => number} [getClickedIndexFn]
+ *
  * @prop {string=} arrowPrevSVG
  * @prop {string=} arrowNextSVG
- * @prop {string=} mainClass
- * @prop {string=} closeTitle
- * @prop {string=} zoomTitle
- * @prop {string=} arrowPrevTitle
- * @prop {string=} arrowNextTitle
+ *
  * @prop {boolean=} arrowPrev
  * @prop {boolean=} arrowNext
  * @prop {boolean=} zoom
  * @prop {boolean=} close
  * @prop {boolean=} counter
- * @prop {ZoomLevel=} initialZoomLevel
- * @prop {ZoomLevel=} secondaryZoomLevel
- * @prop {ZoomLevel=} maxZoomLevel
+ *
+ * @prop {ZoomLevelOption=} initialZoomLevel
+ * @prop {ZoomLevelOption=} secondaryZoomLevel
+ * @prop {ZoomLevelOption=} maxZoomLevel
+ *
  * @prop {boolean=} mouseMovePan
  * @prop {Promise<any>} [openPromise] // TODO
- * @prop {HTMLElement=} appendToEl
  * @prop {Point | null} [initialPointerPos]
- * @prop {(options: PhotoSwipeOptions, pswp: PhotoSwipe) => { x: number; y: number }} [getViewportSizeFn]
- */
-
-/**
- * @typedef {_PhotoSwipeItemProps & Record<string, any>} PhotoSwipeItem
- * @typedef {Object} _PhotoSwipeItemProps
- * @prop {HTMLElement=} element
- * @prop {string=} src
- * @prop {string=} srcset
- * @prop {number=} w
- * @prop {number=} h
- * @prop {string=} msrc
- * @prop {string=} alt
- * @prop {boolean=} thumbCropped
- * @prop {string=} html
- * @prop {'image' | 'html'} [type]
- * @prop {'image' | 'html'} [type]
  */
 
 /** @type {Partial<PhotoSwipeOptions>} */
@@ -319,9 +389,8 @@ class PhotoSwipe extends PhotoSwipeBase {
 
   /**
    * @see slide/slide.js zoomTo
-   * TODO
    *
-   * @param {any[]} args
+   * @param {Parameters<Slide['zoomTo']>} args
    */
   zoomTo(...args) {
     this.currSlide.zoomTo(...args);
@@ -402,6 +471,7 @@ class PhotoSwipe extends PhotoSwipeBase {
 
         // activate the new slide if it's current
         if (i === 1) {
+          /** @type {Slide} */
           this.currSlide = itemHolder.slide;
           itemHolder.slide.setIsActive(true);
         }

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -234,6 +234,9 @@ const defaultOptions = {
   easing: 'cubic-bezier(.4,0,.22,1)'
 };
 
+/**
+ * PhotoSwipe Core
+ */
 class PhotoSwipe extends PhotoSwipeBase {
   /** @type {HTMLDivElement} */
   topBar;
@@ -400,7 +403,7 @@ class PhotoSwipe extends PhotoSwipeBase {
 
   /**
    * Change the slide
-   * @param  {number} index New index
+   * @param {number} index New index
    */
   goTo(index) {
     this.mainScroll.moveIndexBy(

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -80,13 +80,13 @@ import ContentLoader from './slide/loader.js';
  * @prop {(viewportSize: Size, itemData: SlideData, index: number) => Padding} [paddingFn]
  * The option is checked frequently, so make sure it's performant. Overrides padding option if defined. For example:
  *
- * @prop {number=} hideAnimationDuration
+ * @prop {number | false} [hideAnimationDuration]
  * Transition duration in milliseconds, can be 0.
  *
- * @prop {number=} showAnimationDuration
+ * @prop {number | false} [showAnimationDuration]
  * Transition duration in milliseconds, can be 0.
  *
- * @prop {number=} zoomAnimationDuration
+ * @prop {number | false} [zoomAnimationDuration]
  * Transition duration in milliseconds, can be 0.
  *
  * @prop {string=} easing
@@ -104,16 +104,16 @@ import ContentLoader from './slide/loader.js';
  * @prop {boolean=} clickToCloseNonZoomable
  * If image is not zoomable (for example, smaller than viewport) it can be closed by clicking on it.
  *
- * @prop {ActionType | ActionFn} [imageClickAction]
+ * @prop {ActionType | ActionFn | false} [imageClickAction]
  * Refer to click and tap actions page.
  *
- * @prop {ActionType | ActionFn} [bgClickAction]
+ * @prop {ActionType | ActionFn | false} [bgClickAction]
  * Refer to click and tap actions page.
  *
- * @prop {ActionType | ActionFn} [tapAction]
+ * @prop {ActionType | ActionFn | false} [tapAction]
  * Refer to click and tap actions page.
  *
- * @prop {ActionType | ActionFn} [doubleTapAction]
+ * @prop {ActionType | ActionFn | false} [doubleTapAction]
  * Refer to click and tap actions page.
  *
  * @prop {number=} preloaderDelay

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -155,14 +155,23 @@ import ContentLoader from './slide/loader.js';
  *
  * @prop {(pswp: PhotoSwipeLightbox, e: Event) => number} [getClickedIndexFn]
  *
- * @prop {string=} arrowPrevSVG
- * @prop {string=} arrowNextSVG
- *
  * @prop {boolean=} arrowPrev
  * @prop {boolean=} arrowNext
  * @prop {boolean=} zoom
  * @prop {boolean=} close
  * @prop {boolean=} counter
+ *
+ * @prop {string=} arrowPrevSVG
+ * @prop {string=} arrowNextSVG
+ * @prop {string=} zoomSVG
+ * @prop {string=} closeSVG
+ * @prop {string=} counterSVG
+ *
+ * @prop {string=} arrowPrevTitle
+ * @prop {string=} arrowNextTitle
+ * @prop {string=} zoomTitle
+ * @prop {string=} closeTitle
+ * @prop {string=} counterTitle
  *
  * @prop {ZoomLevelOption=} initialZoomLevel
  * @prop {ZoomLevelOption=} secondaryZoomLevel
@@ -203,6 +212,9 @@ const defaultOptions = {
 };
 
 class PhotoSwipe extends PhotoSwipeBase {
+  /** @type {HTMLDivElement} */
+  topBar;
+
   /**
    * @param {PhotoSwipeOptions} options
    */

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -159,7 +159,7 @@ import ContentLoader from './slide/loader.js';
  * @prop {number=} index
  * Defines start slide index.
  *
- * @prop {(pswp: PhotoSwipeLightbox, e: Event) => number} [getClickedIndexFn]
+ * @prop {(e: MouseEvent) => number} [getClickedIndexFn]
  *
  * @prop {boolean=} arrowPrev
  * @prop {boolean=} arrowNext
@@ -184,11 +184,14 @@ import ContentLoader from './slide/loader.js';
  * @prop {ZoomLevelOption=} maxZoomLevel
  *
  * @prop {boolean=} mouseMovePan
- * @prop {Promise<any>} [openPromise] // TODO
  * @prop {Point | null} [initialPointerPos]
  * @prop {boolean=} showHideOpacity
  *
+ * @prop {Promise<PhotoSwipe> | (() => Promise<PhotoSwipe>)} [pswpModule]
+ * @prop {() => Promise<any>} [openPromise]
+ * @prop {boolean=} preloadFirstSlide
  * @prop {string=} gallery
+ * @prop {string=} gallerySelector
  * @prop {string=} children
  * @prop {string=} childSelector
  * @prop {string | false} [thumbSelector]

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -27,10 +27,13 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {{ x?: number; y?: number }} Size */
 /** @typedef {{ top: number; bottom: number; left: number; right: number }} Padding */
 
+/** @typedef {SlideData[]} DataSourceArray */
+/** @typedef {{ gallery: HTMLElement; items?: HTMLElement[] }} DataSourceObject */
+
 /**
  * @typedef {Object} PhotoSwipeOptions
  *
- * @prop {SlideData[]} dataSource
+ * @prop {DataSourceArray | DataSourceObject} dataSource
  * Pass an array of any items via dataSource option. Its length will determine amount of slides
  * (which may be modified further from numItems event).
  *
@@ -180,6 +183,12 @@ import ContentLoader from './slide/loader.js';
  * @prop {boolean=} mouseMovePan
  * @prop {Promise<any>} [openPromise] // TODO
  * @prop {Point | null} [initialPointerPos]
+ * @prop {boolean=} showHideOpacity
+ *
+ * @prop {string=} gallery
+ * @prop {string=} children
+ * @prop {string=} childSelector
+ * @prop {string | false} [thumbSelector]
  */
 
 /** @type {Partial<PhotoSwipeOptions>} */

--- a/src/js/scroll-wheel.js
+++ b/src/js/scroll-wheel.js
@@ -1,13 +1,22 @@
+/** @typedef {import("./photoswipe").default} PhotoSwipe */
+
 /**
  * Handles scroll wheel.
  * Can pan and zoom current slide image.
  */
 class ScrollWheel {
+  /**
+   * @param {PhotoSwipe} pswp
+   */
   constructor(pswp) {
     this.pswp = pswp;
     pswp.events.add(pswp.element, 'wheel', this._onWheel.bind(this));
   }
 
+  /**
+   * @private
+   * @param {WheelEvent} e
+   */
   _onWheel(e) {
     e.preventDefault();
     const { currSlide } = this.pswp;

--- a/src/js/slide/content.js
+++ b/src/js/slide/content.js
@@ -374,8 +374,9 @@ class Content {
         });
       } else {
         if (this.placeholder
-          // @ts-expect-error
-          && (this.state === LOAD_STATE.LOADED || this.state === LOAD_STATE.ERROR)) {
+          // eslint-disable-next-line max-len
+          && (this.state === LOAD_STATE.LOADED || /** @type {LoadState} */ (this.state) === LOAD_STATE.ERROR)
+        ) {
           this.removePlaceholder();
         }
         this.appendImage();

--- a/src/js/slide/content.js
+++ b/src/js/slide/content.js
@@ -1,13 +1,19 @@
 import { createElement, LOAD_STATE, setWidthHeight } from '../util/util.js';
 import Placeholder from './placeholder.js';
 
+/** @typedef {import("./slide").default} Slide */
+/** @typedef {import("./slide").SlideData} SlideData */
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("../util/util").LoadState} LoadState */
+
 class Content {
+  /** @type {HTMLImageElement | HTMLDivElement} */
+  element;
+
   /**
-   * @param {Object} itemData Slide data
-   * @param {PhotoSwipeBase} instance PhotoSwipe or PhotoSwipeLightbox instance
-   * @param {Slide|undefined} slide Slide that requested the image,
-   *                                can be undefined if image was requested by something else
-   *                                (for example by lazy-loader)
+   * @param {SlideData} itemData Slide data
+   * @param {PhotoSwipe} instance PhotoSwipe or PhotoSwipeLightbox instance
+   * @param {number} index
    */
   constructor(itemData, instance, index) {
     this.instance = instance;
@@ -19,6 +25,7 @@ class Content {
 
     this.isAttached = false;
     this.hasSlide = false;
+    /** @type {LoadState} */
     this.state = LOAD_STATE.IDLE;
 
     if (this.data.type) {
@@ -47,7 +54,8 @@ class Content {
   /**
    * Preload content
    *
-   * @param {Boolean} isLazy
+   * @param {boolean=} isLazy
+   * @param {boolean=} reload
    */
   load(isLazy, reload) {
     if (!this.placeholder && this.slide && this.usePlaceholder()) {
@@ -87,33 +95,34 @@ class Content {
   /**
    * Preload image
    *
-   * @param {Boolean} isLazy
+   * @param {boolean} isLazy
    */
   loadImage(isLazy) {
-    this.element = createElement('pswp__img', 'img');
+    const imageElement = createElement('pswp__img', 'img');
+    this.element = imageElement;
 
     if (this.instance.dispatch('contentLoadImage', { content: this, isLazy }).defaultPrevented) {
       return;
     }
 
     if (this.data.srcset) {
-      this.element.srcset = this.data.srcset;
+      imageElement.srcset = this.data.srcset;
     }
 
-    this.element.src = this.data.src;
+    imageElement.src = this.data.src;
 
-    this.element.alt = this.data.alt || '';
+    imageElement.alt = this.data.alt || '';
 
     this.state = LOAD_STATE.LOADING;
 
-    if (this.element.complete) {
+    if (imageElement.complete) {
       this.onLoaded();
     } else {
-      this.element.onload = () => {
+      imageElement.onload = () => {
         this.onLoaded();
       };
 
-      this.element.onerror = () => {
+      imageElement.onerror = () => {
         this.onError();
       };
     }
@@ -181,7 +190,7 @@ class Content {
   }
 
   /**
-   * @returns {Boolean} If the content is image
+   * @returns {boolean} If the content is image
    */
   isImageContent() {
     return this.type === 'image';
@@ -202,6 +211,7 @@ class Content {
       this.placeholder.setDisplayedSize(width, height);
     }
 
+    // eslint-disable-next-line max-len
     if (this.instance.dispatch('contentResize', { content: this, width, height }).defaultPrevented) {
       return;
     }
@@ -209,26 +219,29 @@ class Content {
     setWidthHeight(this.element, width, height);
 
     if (this.isImageContent() && !this.isError()) {
-      const image = this.element;
+      const image = /** @type HTMLImageElement */ (this.element);
+
       // Handle srcset sizes attribute.
       //
       // Never lower quality, if it was increased previously.
       // Chrome does this automatically, Firefox and Safari do not,
       // so we store largest used size in dataset.
       if (image.srcset
-          && (!image.dataset.largestUsedSize || width > image.dataset.largestUsedSize)) {
+          // eslint-disable-next-line max-len
+          && (!image.dataset.largestUsedSize || width > parseInt(image.dataset.largestUsedSize, 10))) {
         image.sizes = width + 'px';
-        image.dataset.largestUsedSize = width;
+        image.dataset.largestUsedSize = String(width);
       }
 
       if (this.slide) {
+        // eslint-disable-next-line max-len
         this.instance.dispatch('imageSizeChange', { slide: this.slide, width, height, content: this });
       }
     }
   }
 
   /**
-   * @returns {Boolean} If the content can be zoomed
+   * @returns {boolean} If the content can be zoomed
    */
   isZoomable() {
     return this.instance.applyFilters(
@@ -239,7 +252,7 @@ class Content {
   }
 
   /**
-   * @returns {Boolean} If content should use a placeholder (from msrc by default)
+   * @returns {boolean} If content should use a placeholder (from msrc by default)
    */
   usePlaceholder() {
     return this.instance.applyFilters(
@@ -251,8 +264,6 @@ class Content {
 
   /**
    * Preload content with lazy-loading param
-   *
-   * @param {Boolean} isLazy
    */
   lazyLoad() {
     if (this.instance.dispatch('contentLazyLoad', { content: this }).defaultPrevented) {
@@ -263,7 +274,7 @@ class Content {
   }
 
   /**
-   * @returns {Boolean} If placeholder should be kept after content is loaded
+   * @returns {boolean} If placeholder should be kept after content is loaded
    */
   keepPlaceholder() {
     return this.instance.applyFilters(
@@ -349,7 +360,8 @@ class Content {
         requestAnimationFrame(() => {
           // element might change
           if (this.element && this.element.tagName === 'IMG') {
-            this.element.decode().then(() => {
+            /** @type {HTMLImageElement} */
+            (this.element).decode().then(() => {
               this.isDecoding = false;
               requestAnimationFrame(() => {
                 this.appendImage();
@@ -361,6 +373,7 @@ class Content {
         });
       } else {
         if (this.placeholder
+          // @ts-expect-error
           && (this.state === LOAD_STATE.LOADED || this.state === LOAD_STATE.ERROR)) {
           this.removePlaceholder();
         }

--- a/src/js/slide/content.js
+++ b/src/js/slide/content.js
@@ -309,6 +309,7 @@ class Content {
    */
   displayError() {
     if (this.slide) {
+      /** @type {HTMLElement} */
       let errorMsgEl = createElement('pswp__error-msg');
       errorMsgEl.innerText = this.instance.options.errorMsg;
       errorMsgEl = this.instance.applyFilters(

--- a/src/js/slide/get-thumb-bounds.js
+++ b/src/js/slide/get-thumb-bounds.js
@@ -1,3 +1,11 @@
+/** @typedef {import("./slide").SlideData} SlideData */
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+
+/** @typedef {{ x: number; y: number; w: number; innerRect?: { w: number; h: number; x: number; y: number } }} Bounds */
+
+/**
+ * @param {HTMLElement} el
+ */
 function getBoundsByElement(el) {
   const thumbAreaRect = el.getBoundingClientRect();
   return {
@@ -7,6 +15,11 @@ function getBoundsByElement(el) {
   };
 }
 
+/**
+ * @param {HTMLElement} el
+ * @param {number} imageWidth
+ * @param {number} imageHeight
+ */
 function getCroppedBoundsByElement(el, imageWidth, imageHeight) {
   const thumbAreaRect = el.getBoundingClientRect();
 
@@ -19,9 +32,13 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight) {
   const offsetX = (thumbAreaRect.width - imageWidth * fillZoomLevel) / 2;
   const offsetY = (thumbAreaRect.height - imageHeight * fillZoomLevel) / 2;
 
-  // Coordinates of the image,
-  // as if it was not cropped,
-  // height is calculated automatically
+  /**
+   * Coordinates of the image,
+   * as if it was not cropped,
+   * height is calculated automatically
+   *
+   * @type {Bounds}
+   */
   const bounds = {
     x: thumbAreaRect.left + offsetX,
     y: thumbAreaRect.top + offsetY,
@@ -44,10 +61,10 @@ function getCroppedBoundsByElement(el, imageWidth, imageHeight) {
  * Get dimensions of thumbnail image
  * (click on which opens photoswipe or closes photoswipe to)
  *
- * @param {Integer} index
- * @param {Object} itemData
+ * @param {number} index
+ * @param {SlideData} itemData
  * @param {PhotoSwipe} instance PhotoSwipe instance
- * @returns Object|undefined
+ * @returns {Bounds | undefined}
  */
 export function getThumbBounds(index, itemData, instance) {
   // legacy event, before filters were introduced
@@ -56,7 +73,9 @@ export function getThumbBounds(index, itemData, instance) {
     itemData,
     instance
   });
+  // @ts-expect-error
   if (event.thumbBounds) {
+    // @ts-expect-error
     return event.thumbBounds;
   }
 

--- a/src/js/slide/get-thumb-bounds.js
+++ b/src/js/slide/get-thumb-bounds.js
@@ -81,6 +81,7 @@ export function getThumbBounds(index, itemData, instance) {
 
   const { element } = itemData;
   let thumbBounds;
+  /** @type {HTMLElement} */
   let thumbnail;
 
   if (element && instance.options.thumbSelector !== false) {

--- a/src/js/slide/loader.js
+++ b/src/js/slide/loader.js
@@ -32,7 +32,7 @@ export function lazyLoadData(itemData, instance, index) {
   // We need to know dimensions of the image to preload it,
   // as it might use srcset and we need to define sizes
   // @ts-expect-error should provide pswp instance?
-  const viewportSize = instance.viewportSize || getViewportSize(options);
+  const viewportSize = instance.viewportSize || getViewportSize(options, instance);
   const panAreaSize = getPanAreaSize(options, viewportSize, itemData, index);
 
   const zoomLevel = new ZoomLevel(options, itemData, -1);

--- a/src/js/slide/loader.js
+++ b/src/js/slide/loader.js
@@ -1,6 +1,11 @@
 import { getViewportSize, getPanAreaSize } from '../util/viewport-size.js';
 import ZoomLevel from './zoom-level.js';
 
+/** @typedef {import("./content").default} Content */
+/** @typedef {import("./slide").default} Slide */
+/** @typedef {import("./slide").SlideData} SlideData */
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+
 const MIN_SLIDES_TO_CACHE = 5;
 
 /**
@@ -8,10 +13,10 @@ const MIN_SLIDES_TO_CACHE = 5;
  * This function is used both by Lightbox and PhotoSwipe core,
  * thus it can be called before dialog is opened.
  *
- * @param {Object} itemData Data about the slide
- * @param {PhotoSwipeBase}  instance PhotoSwipe or PhotoSwipeLightbox
- * @param {Integer} index
- * @returns {Object|Boolean} Image that is being decoded or false.
+ * @param {SlideData} itemData Data about the slide
+ * @param {PhotoSwipe} instance PhotoSwipe or PhotoSwipeLightbox
+ * @param {number} index
+ * @returns Image that is being decoded or false.
  */
 export function lazyLoadData(itemData, instance, index) {
   // src/slide/content/content.js
@@ -25,6 +30,7 @@ export function lazyLoadData(itemData, instance, index) {
 
   // We need to know dimensions of the image to preload it,
   // as it might use srcset and we need to define sizes
+  // @ts-expect-error should provide pswp instance?
   const viewportSize = instance.viewportSize || getViewportSize(options);
   const panAreaSize = getPanAreaSize(options, viewportSize, itemData, index);
 
@@ -48,8 +54,8 @@ export function lazyLoadData(itemData, instance, index) {
  *
  * By default it loads image based on viewport size and initial zoom level.
  *
- * @param {Integer} index Slide index
- * @param {Object}  instance PhotoSwipe or PhotoSwipeLightbox eventable instance
+ * @param {number} index Slide index
+ * @param {PhotoSwipe} instance PhotoSwipe or PhotoSwipeLightbox eventable instance
  */
 export function lazyLoadSlide(index, instance) {
   const itemData = instance.getItemData(index);
@@ -63,6 +69,9 @@ export function lazyLoadSlide(index, instance) {
 
 
 class ContentLoader {
+  /**
+   * @param {PhotoSwipe} pswp
+   */
   constructor(pswp) {
     this.pswp = pswp;
     // Total amount of cached images
@@ -70,13 +79,14 @@ class ContentLoader {
       pswp.options.preload[0] + pswp.options.preload[1] + 1,
       MIN_SLIDES_TO_CACHE
     );
+    /** @type {Content[]} */
     this._cachedItems = [];
   }
 
   /**
    * Lazy load nearby slides based on `preload` option.
    *
-   * @param {Integer} diff Difference between slide indexes that was changed recently, or 0.
+   * @param {number=} diff Difference between slide indexes that was changed recently, or 0.
    */
   updateLazy(diff) {
     const { pswp } = this;
@@ -100,6 +110,9 @@ class ContentLoader {
     }
   }
 
+  /**
+   * @param {number} index
+   */
   loadSlideByIndex(index) {
     index = this.pswp.getLoopedIndex(index);
     // try to get cached content
@@ -114,6 +127,9 @@ class ContentLoader {
     }
   }
 
+  /**
+   * @param {Slide} slide
+   */
   getContentBySlide(slide) {
     let content = this.getContentByIndex(slide.index);
     if (!content) {
@@ -154,7 +170,7 @@ class ContentLoader {
   /**
    * Removes an image from cache, does not destroy() it, just removes.
    *
-   * @param {Integer} index
+   * @param {number} index
    */
   removeByIndex(index) {
     const indexToRemove = this._cachedItems.findIndex(item => item.index === index);
@@ -163,6 +179,9 @@ class ContentLoader {
     }
   }
 
+  /**
+   * @param {number} index
+   */
   getContentByIndex(index) {
     return this._cachedItems.find(content => content.index === index);
   }

--- a/src/js/slide/loader.js
+++ b/src/js/slide/loader.js
@@ -5,6 +5,7 @@ import ZoomLevel from './zoom-level.js';
 /** @typedef {import("./slide").default} Slide */
 /** @typedef {import("./slide").SlideData} SlideData */
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("../lightbox/lightbox").default} PhotoSwipeLightbox */
 
 const MIN_SLIDES_TO_CACHE = 5;
 
@@ -14,7 +15,7 @@ const MIN_SLIDES_TO_CACHE = 5;
  * thus it can be called before dialog is opened.
  *
  * @param {SlideData} itemData Data about the slide
- * @param {PhotoSwipe} instance PhotoSwipe or PhotoSwipeLightbox
+ * @param {PhotoSwipe | PhotoSwipeLightbox} instance PhotoSwipe or PhotoSwipeLightbox
  * @param {number} index
  * @returns Image that is being decoded or false.
  */
@@ -55,7 +56,7 @@ export function lazyLoadData(itemData, instance, index) {
  * By default it loads image based on viewport size and initial zoom level.
  *
  * @param {number} index Slide index
- * @param {PhotoSwipe} instance PhotoSwipe or PhotoSwipeLightbox eventable instance
+ * @param {PhotoSwipe | PhotoSwipeLightbox} instance PhotoSwipe or PhotoSwipeLightbox eventable instance
  */
 export function lazyLoadSlide(index, instance) {
   const itemData = instance.getItemData(index);

--- a/src/js/slide/pan-bounds.js
+++ b/src/js/slide/pan-bounds.js
@@ -6,20 +6,34 @@ import {
 } from '../util/util.js';
 import { parsePaddingOption } from '../util/viewport-size.js';
 
+/** @typedef {import("./slide").default} Slide */
+/** @typedef {{ x?: number; y?: number }} Point */
+/** @typedef {'x' | 'y'} Axis */
+
 class PanBounds {
+  /**
+   * @param {Slide} slide
+   */
   constructor(slide) {
     this.slide = slide;
 
     this.currZoomLevel = 1;
 
+    /** @type {Point} */
     this.center = {};
+    /** @type {Point} */
     this.max = {};
+    /** @type {Point} */
     this.min = {};
 
     this.reset();
   }
 
-  // _getItemBounds
+  /**
+   * _getItemBounds
+   *
+   * @param {number} currZoomLevel
+   */
   update(currZoomLevel) {
     this.currZoomLevel = currZoomLevel;
 
@@ -32,7 +46,11 @@ class PanBounds {
     }
   }
 
-  // _calculateItemBoundsForAxis
+  /**
+   * _calculateItemBoundsForAxis
+   *
+   * @param {Axis} axis
+   */
   _updateAxis(axis) {
     const { pswp } = this.slide;
     const elSize = this.slide[axis === 'x' ? 'width' : 'height'] * this.currZoomLevel;
@@ -75,8 +93,8 @@ class PanBounds {
   /**
    * Correct pan position if it's beyond the bounds
    *
-   * @param {String} axis x or y
-   * @param {Object} panOffset
+   * @param {Axis} axis x or y
+   * @param {number} panOffset
    */
   correctPan(axis, panOffset) { // checkPanBounds
     return clamp(panOffset, this.max[axis], this.min[axis]);

--- a/src/js/slide/pan-bounds.js
+++ b/src/js/slide/pan-bounds.js
@@ -1,6 +1,3 @@
-/**
- * Calculates minimum, maximum and initial (center) bounds of a slide
- */
 import {
   clamp
 } from '../util/util.js';
@@ -10,6 +7,9 @@ import { parsePaddingOption } from '../util/viewport-size.js';
 /** @typedef {{ x?: number; y?: number }} Point */
 /** @typedef {'x' | 'y'} Axis */
 
+/**
+ * Calculates minimum, maximum and initial (center) bounds of a slide
+ */
 class PanBounds {
   /**
    * @param {Slide} slide

--- a/src/js/slide/placeholder.js
+++ b/src/js/slide/placeholder.js
@@ -2,8 +2,8 @@ import { createElement, setWidthHeight, toTransformString } from '../util/util.j
 
 class Placeholder {
   /**
-   * @param {String|false} imageSrc
-   * @param {Element} container
+   * @param {string | false} imageSrc
+   * @param {HTMLElement} container
    */
   constructor(imageSrc, container) {
     // Create placeholder
@@ -15,15 +15,22 @@ class Placeholder {
     );
 
     if (imageSrc) {
-      this.element.decoding = 'async';
-      this.element.alt = '';
-      this.element.src = imageSrc;
+      /** @type {HTMLImageElement} */
+      (this.element).decoding = 'async';
+      /** @type {HTMLImageElement} */
+      (this.element).alt = '';
+      /** @type {HTMLImageElement} */
+      (this.element).src = imageSrc;
       this.element.setAttribute('role', 'presentation');
     }
 
     this.element.setAttribute('aria-hiden', 'true');
   }
 
+  /**
+   * @param {number} width
+   * @param {number} height
+   */
   setDisplayedSize(width, height) {
     if (!this.element) {
       return;

--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -1,5 +1,20 @@
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("../photoswipe").Point} Point */
+
 /**
- * Renders and allows to control a single slide
+ * @typedef {_SlideData & Record<string, any>} SlideData
+ * @typedef {Object} _SlideData
+ * @prop {HTMLElement=} element
+ * @prop {string=} src
+ * @prop {string=} srcset
+ * @prop {number=} w
+ * @prop {number=} h
+ * @prop {string=} msrc
+ * @prop {string=} alt
+ * @prop {boolean=} thumbCropped
+ * @prop {string=} html
+ * @prop {'image' | 'html'} [type]
+ * @prop {'image' | 'html'} [type]
  */
 
 import {
@@ -15,13 +30,22 @@ import PanBounds from './pan-bounds.js';
 import ZoomLevel from './zoom-level.js';
 import { getPanAreaSize } from '../util/viewport-size.js';
 
+/**
+ * Renders and allows to control a single slide
+ */
 class Slide {
+  /**
+   * @param {SlideData} data
+   * @param {number} index
+   * @param {PhotoSwipe} pswp
+   */
   constructor(data, index, pswp) {
     this.data = data;
     this.index = index;
     this.pswp = pswp;
     this.isActive = (index === pswp.currIndex);
     this.currentResolution = 0;
+    /** @type {Point} */
     this.panAreaSize = {};
 
     this.isFirstSlide = (this.isActive && !pswp.opener.isOpen);
@@ -43,7 +67,9 @@ class Slide {
     this.container = createElement('pswp__zoom-wrap');
 
     this.currZoomLevel = 1;
+    /** @type {number} */
     this.width = this.content.width;
+    /** @type {number} */
     this.height = this.content.height;
 
     this.bounds = new PanBounds(this);
@@ -57,7 +83,7 @@ class Slide {
   /**
    * If this slide is active/current/visible
    *
-   * @param {Boolean} isActive
+   * @param {boolean} isActive
    */
   setIsActive(isActive) {
     if (isActive && !this.isActive) {
@@ -71,6 +97,8 @@ class Slide {
 
   /**
    * Appends slide content to DOM
+   *
+   * @param {HTMLElement} holderElement
    */
   append(holderElement) {
     this.holderElement = holderElement;
@@ -83,6 +111,7 @@ class Slide {
 
     this.calculateSize();
 
+    // @ts-expect-error: should be `this.container.style.transformOrigin`?
     this.container.transformOrigin = '0 0';
 
     this.load();
@@ -204,7 +233,7 @@ class Slide {
    * Apply size to current slide content,
    * based on the current resolution and scale.
    *
-   * @param {Boolean} force if size should be updated even if dimensions weren't changed
+   * @param {boolean=} force if size should be updated even if dimensions weren't changed
    */
   updateContentSize(force) {
     // Use initial zoom level
@@ -224,6 +253,10 @@ class Slide {
     this.content.setDisplayedSize(width, height);
   }
 
+  /**
+   * @param {number} width
+   * @param {number} height
+   */
   sizeChanged(width, height) {
     if (width !== this.prevDisplayedWidth
         || height !== this.prevDisplayedHeight) {
@@ -244,12 +277,12 @@ class Slide {
   /**
    * Zoom current slide image to...
    *
-   * @param  {Number} destZoomLevel      Destination zoom level.
-   * @param  {Object|false} centerPoint  Transform origin center point,
-   *                                     or false if viewport center should be used.
-   * @param  {Number} transitionDuration Transition duration, may be set to 0.
-   * @param  {Boolean|null} ignoreBounds Minimum and maximum zoom levels will be ignored.
-   * @return {Boolean|null}              Returns true if animated.
+   * @param {number} destZoomLevel Destination zoom level.
+   * @param {{ x: number; y: number }} centerPoint
+   * Transform origin center point, or false if viewport center should be used.
+   * @param {number=} transitionDuration Transition duration, may be set to 0.
+   * @param {boolean=} ignoreBounds Minimum and maximum zoom levels will be ignored.
+   * @return {boolean=} Returns true if animated.
    */
   zoomTo(destZoomLevel, centerPoint, transitionDuration, ignoreBounds) {
     const { pswp } = this;
@@ -304,6 +337,9 @@ class Slide {
     }
   }
 
+  /**
+   * @param {{ x: number, y: number }} [centerPoint]
+   */
   toggleZoom(centerPoint) {
     this.zoomTo(
       this.currZoomLevel === this.zoomLevels.initial
@@ -317,7 +353,7 @@ class Slide {
    * Updates zoom level property and recalculates new pan bounds,
    * unlike zoomTo it does not apply transform (use applyCurrentZoomPan)
    *
-   * @param {Number} currZoomLevel
+   * @param {number} currZoomLevel
    */
   setZoomLevel(currZoomLevel) {
     this.currZoomLevel = currZoomLevel;
@@ -330,11 +366,11 @@ class Slide {
    * Always call setZoomLevel(newZoomLevel) beforehand to recalculate
    * pan bounds according to the new zoom level.
    *
-   * @param {String} axis
-   * @param {Object|null} centerPoint point based on which zoom is performed,
-   *                                  usually refers to the current mouse position,
-   *                                  if false - viewport center will be used.
-   * @param {Number|null} prevZoomLevel Zoom level before new zoom was applied.
+   * @param {'x' | 'y'} axis
+   * @param {{ x: number; y: number }} [point]
+   * point based on which zoom is performed, usually refers to the current mouse position,
+   * if false - viewport center will be used.
+   * @param {number=} prevZoomLevel Zoom level before new zoom was applied.
    */
   calculateZoomToPanOffset(axis, point, prevZoomLevel) {
     const totalPanDistance = this.bounds.max[axis] - this.bounds.min[axis];
@@ -356,8 +392,8 @@ class Slide {
   /**
    * Apply pan and keep it within bounds.
    *
-   * @param {Number} panX
-   * @param {Number} panY
+   * @param {number} panX
+   * @param {number} panY
    */
   panTo(panX, panY) {
     this.pan.x = this.bounds.correctPan('x', panX);
@@ -402,9 +438,9 @@ class Slide {
   /**
    * Set translate and scale based on current resolution
    *
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Number} zoom
+   * @param {number} x
+   * @param {number} y
+   * @param {number} zoom
    */
   _applyZoomTransform(x, y, zoom) {
     zoom /= this.currentResolution || this.zoomLevels.initial;
@@ -444,7 +480,7 @@ class Slide {
    * sure that browser renders image in highest quality.
    * Also used by responsive images to load the correct one.
    *
-   * @param {Number} newResolution
+   * @param {number} newResolution
    */
   _setResolution(newResolution) {
     if (newResolution === this.currentResolution) {

--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -113,7 +113,7 @@ class Slide {
     this.calculateSize();
 
     // @ts-expect-error: should be `this.container.style.transformOrigin`?
-    this.container.transformOrigin = '0 0';
+    this.container.style.transformOrigin = '0 0';
 
     this.load();
     this.appendHeavy();

--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -279,7 +279,7 @@ class Slide {
    * Zoom current slide image to...
    *
    * @param {number} destZoomLevel Destination zoom level.
-   * @param {{ x: number; y: number }} centerPoint
+   * @param {{ x?: number; y?: number }} centerPoint
    * Transform origin center point, or false if viewport center should be used.
    * @param {number=} transitionDuration Transition duration, may be set to 0.
    * @param {boolean=} ignoreBounds Minimum and maximum zoom levels will be ignored.
@@ -339,7 +339,7 @@ class Slide {
   }
 
   /**
-   * @param {{ x: number, y: number }} [centerPoint]
+   * @param {{ x?: number, y?: number }} [centerPoint]
    */
   toggleZoom(centerPoint) {
     this.zoomTo(
@@ -368,7 +368,7 @@ class Slide {
    * pan bounds according to the new zoom level.
    *
    * @param {'x' | 'y'} axis
-   * @param {{ x: number; y: number }} [point]
+   * @param {{ x?: number; y?: number }} [point]
    * point based on which zoom is performed, usually refers to the current mouse position,
    * if false - viewport center will be used.
    * @param {number=} prevZoomLevel Zoom level before new zoom was applied.

--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -281,7 +281,7 @@ class Slide {
    * @param {number} destZoomLevel Destination zoom level.
    * @param {{ x?: number; y?: number }} centerPoint
    * Transform origin center point, or false if viewport center should be used.
-   * @param {number=} transitionDuration Transition duration, may be set to 0.
+   * @param {number | false} [transitionDuration] Transition duration, may be set to 0.
    * @param {boolean=} ignoreBounds Minimum and maximum zoom levels will be ignored.
    * @return {boolean=} Returns true if animated.
    */

--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -4,18 +4,18 @@
 /**
  * @typedef {_SlideData & Record<string, any>} SlideData
  * @typedef {Object} _SlideData
- * @prop {HTMLElement=} element
- * @prop {string=} src
- * @prop {string=} srcset
- * @prop {number=} w deprecated
- * @prop {number=} h deprecated
- * @prop {number=} width
- * @prop {number=} height
- * @prop {string=} msrc
- * @prop {string=} alt
- * @prop {boolean=} thumbCropped
- * @prop {string=} html
- * @prop {'image' | 'html' | string} [type]
+ * @prop {HTMLElement=} element thumbnail element
+ * @prop {string=} src image URL
+ * @prop {string=} srcset image srcset
+ * @prop {number=} w image width (deprecated)
+ * @prop {number=} h image height (deprecated)
+ * @prop {number=} width image width
+ * @prop {number=} height image height
+ * @prop {string=} msrc placeholder image URL that's displayed before large image is loaded
+ * @prop {string=} alt image alt text
+ * @prop {boolean=} thumbCropped whether thumbnail is cropped client-side or not
+ * @prop {string=} html html content of a slide
+ * @prop {'image' | 'html' | string} [type] slide type
  */
 
 import {

--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -7,14 +7,15 @@
  * @prop {HTMLElement=} element
  * @prop {string=} src
  * @prop {string=} srcset
- * @prop {number=} w
- * @prop {number=} h
+ * @prop {number=} w deprecated
+ * @prop {number=} h deprecated
+ * @prop {number=} width
+ * @prop {number=} height
  * @prop {string=} msrc
  * @prop {string=} alt
  * @prop {boolean=} thumbCropped
  * @prop {string=} html
- * @prop {'image' | 'html'} [type]
- * @prop {'image' | 'html'} [type]
+ * @prop {'image' | 'html' | string} [type]
  */
 
 import {

--- a/src/js/slide/zoom-level.js
+++ b/src/js/slide/zoom-level.js
@@ -1,16 +1,21 @@
+const MAX_IMAGE_WIDTH = 4000;
+
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
+/** @typedef {import("../slide/slide").SlideData} SlideData */
+
+/** @typedef {'fit' | 'fill' | number | ((zoomLevelObject: ZoomLevel) => number)} ZoomLevelOption */
+
 /**
  * Calculates zoom levels for specific slide.
  * Depends on viewport size and image size.
  */
-
-const MAX_IMAGE_WIDTH = 4000;
-
 class ZoomLevel {
   /**
-   * @param {Object} options PhotoSwipe options
-   * @param {Object} itemData Slide data
-   * @param {Integer} index Slide index
-   * @param {PhotoSwipe|undefined} pswp PhotoSwipe instance, can be undefined if not initialized yet
+   * @param {PhotoSwipeOptions} options PhotoSwipe options
+   * @param {SlideData} itemData Slide data
+   * @param {number} index Slide index
+   * @param {PhotoSwipe=} pswp PhotoSwipe instance, can be undefined if not initialized yet
    */
   constructor(options, itemData, index, pswp) {
     this.pswp = pswp;
@@ -24,7 +29,9 @@ class ZoomLevel {
    *
    * It should be called when either image or viewport size changes.
    *
-   * @param {Slide} slide
+   * @param {number} maxWidth
+   * @param {number} maxHeight
+   * @param {{ x?: number; y?: number }} panAreaSize
    */
   update(maxWidth, maxHeight, panAreaSize) {
     this.elementSize = {
@@ -66,13 +73,13 @@ class ZoomLevel {
   /**
    * Parses user-defined zoom option.
    *
-   * @param {Mixed} optionPrefix Zoom level option prefix (initial, secondary, max)
+   * @private
+   * @param {'initial' | 'secondary' | 'max'} optionPrefix Zoom level option prefix (initial, secondary, max)
    */
   _parseZoomLevelOption(optionPrefix) {
-    // zoom.initial
-    // zoom.secondary
-    // zoom.max
-    const optionValue = this.options[optionPrefix + 'ZoomLevel'];
+    // eslint-disable-next-line max-len
+    const optionName = /** @type {'initialZoomLevel' | 'secondaryZoomLevel' | 'maxZoomLevel'} */ (optionPrefix + 'ZoomLevel');
+    const optionValue = this.options[optionName];
 
     if (!optionValue) {
       return;
@@ -99,7 +106,8 @@ class ZoomLevel {
    * or mouse-click on image itself.
    * If you return 1 image will be zoomed to its original size.
    *
-   * @return {Number}
+   * @private
+   * @return {number}
    */
   _getSecondary() {
     let currZoomLevel = this._parseZoomLevelOption('secondary');
@@ -121,7 +129,8 @@ class ZoomLevel {
   /**
    * Get initial image zoom level.
    *
-   * @return {Number}
+   * @private
+   * @return {number}
    */
   _getInitial() {
     return this._parseZoomLevelOption('initial') || this.fit;
@@ -132,7 +141,8 @@ class ZoomLevel {
    * via zoom/pinch gesture,
    * via cmd/ctrl-wheel or via trackpad.
    *
-   * @return {Number}
+   * @private
+   * @return {number}
    */
   _getMax() {
     const currZoomLevel = this._parseZoomLevelOption('max');

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -1,0 +1,7 @@
+export type Methods<T> = {[M in keyof T]: T[M] extends (...a: any) => any ? M : never}[keyof T]
+
+export type AddPostfix<T extends string, P extends string> = `${T}${P}`
+
+export interface Type<T> extends Function {
+  new(...args: any[]): T;
+}

--- a/src/js/ui/button-arrow.js
+++ b/src/js/ui/button-arrow.js
@@ -2,19 +2,31 @@
   Backward and forward arrow buttons
  */
 
+/** @typedef {import("./ui-element").UIElementData} UIElementData */
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+
+/**
+ *
+ * @param {HTMLElement} element
+ * @param {PhotoSwipe} pswp
+ * @param {boolean=} isNextButton
+ */
 function initArrowButton(element, pswp, isNextButton) {
   element.classList.add('pswp__button--arrow');
   pswp.on('change', () => {
     if (!pswp.options.loop) {
       if (isNextButton) {
-        element.disabled = !(pswp.currIndex < pswp.getNumItems() - 1);
+        /** @type {HTMLButtonElement} */
+        (element).disabled = !(pswp.currIndex < pswp.getNumItems() - 1);
       } else {
-        element.disabled = !(pswp.currIndex > 0);
+        /** @type {HTMLButtonElement} */
+        (element).disabled = !(pswp.currIndex > 0);
       }
     }
   });
 }
 
+/** @type {UIElementData} */
 export const arrowPrev = {
   name: 'arrowPrev',
   className: 'pswp__button--arrow--prev',
@@ -32,6 +44,7 @@ export const arrowPrev = {
   onInit: initArrowButton
 };
 
+/** @type {UIElementData} */
 export const arrowNext = {
   name: 'arrowNext',
   className: 'pswp__button--arrow--next',

--- a/src/js/ui/button-close.js
+++ b/src/js/ui/button-close.js
@@ -1,3 +1,4 @@
+/** @type {import("./ui-element").UIElementData} UIElementData */
 const closeButton = {
   name: 'close',
   title: 'Close',

--- a/src/js/ui/button-zoom.js
+++ b/src/js/ui/button-zoom.js
@@ -1,3 +1,4 @@
+/** @type {import("./ui-element").UIElementData} UIElementData */
 const zoomButton = {
   name: 'zoom',
   title: 'Zoom',
@@ -5,6 +6,7 @@ const zoomButton = {
   isButton: true,
   html: {
     isCustomSVG: true,
+    // eslint-disable-next-line max-len
     inner: '<path d="M17.426 19.926a6 6 0 1 1 1.5-1.5L23 22.5 21.5 24l-4.074-4.074z" id="pswp__icn-zoom"/>'
           + '<path fill="currentColor" class="pswp__zoom-icn-bar-h" d="M11 16v-2h6v2z"/>'
           + '<path fill="currentColor" class="pswp__zoom-icn-bar-v" d="M13 12h2v6h-2z"/>',

--- a/src/js/ui/counter-indicator.js
+++ b/src/js/ui/counter-indicator.js
@@ -1,3 +1,4 @@
+/** @type {import("./ui-element").UIElementData} UIElementData */
 export const counterIndicator = {
   name: 'counter',
   order: 5,

--- a/src/js/ui/loading-indicator.js
+++ b/src/js/ui/loading-indicator.js
@@ -54,7 +54,6 @@ export const loadingIndicator = {
 
     pswp.on('change', updatePreloaderVisibility);
 
-    // @ts-expect-error TODO
     pswp.on('loadComplete', (e) => {
       if (pswp.currSlide === e.slide) {
         updatePreloaderVisibility();

--- a/src/js/ui/loading-indicator.js
+++ b/src/js/ui/loading-indicator.js
@@ -1,20 +1,31 @@
+/** @type {import("./ui-element").UIElementData} UIElementData */
 export const loadingIndicator = {
   name: 'preloader',
   appendTo: 'bar',
   order: 7,
   html: {
     isCustomSVG: true,
+    // eslint-disable-next-line max-len
     inner: '<path fill-rule="evenodd" clip-rule="evenodd" d="M21.2 16a5.2 5.2 0 1 1-5.2-5.2V8a8 8 0 1 0 8 8h-2.8Z" id="pswp__icn-loading"/>',
     outlineID: 'pswp__icn-loading'
   },
   onInit: (indicatorElement, pswp) => {
+    /** @type {boolean} */
     let isVisible;
+    /** @type {NodeJS.Timeout} */
     let delayTimeout;
 
+    /**
+     * @param {string} className
+     * @param {boolean} add
+     */
     const toggleIndicatorClass = (className, add) => {
       indicatorElement.classList[add ? 'add' : 'remove']('pswp__preloader--' + className);
     };
 
+    /**
+     * @param {boolean} visible
+     */
     const setIndicatorVisibility = (visible) => {
       if (isVisible !== visible) {
         isVisible = visible;
@@ -43,6 +54,7 @@ export const loadingIndicator = {
 
     pswp.on('change', updatePreloaderVisibility);
 
+    // @ts-expect-error TODO
     pswp.on('loadComplete', (e) => {
       if (pswp.currSlide === e.slide) {
         updatePreloaderVisibility();

--- a/src/js/ui/ui-element.js
+++ b/src/js/ui/ui-element.js
@@ -3,6 +3,11 @@ import { createElement } from '../util/util.js';
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
 
 /**
+ * @template T
+ * @typedef {import("../types").Methods<T>} Methods<T>
+ */
+
+/**
  * @typedef {Object} UIElementMarkupProps
  * @prop {boolean=} isCustomSVG
  * @prop {string} inner

--- a/src/js/ui/ui-element.js
+++ b/src/js/ui/ui-element.js
@@ -56,9 +56,9 @@ function addElementHTML(htmlData) {
 
 /**
  * @typedef {Object} UIElementData
- * @prop {DefaultUIElements=} name
+ * @prop {DefaultUIElements | string} [name]
  * @prop {string=} className
- * @prop {UIElementMarkup} html
+ * @prop {UIElementMarkup=} html
  * @prop {boolean=} isButton
  * @prop {keyof HTMLElementTagNameMap} [tagName]
  * @prop {string=} title
@@ -66,6 +66,7 @@ function addElementHTML(htmlData) {
  * @prop {(element: HTMLElement, pswp: PhotoSwipe) => void} [onInit]
  * @prop {Methods<PhotoSwipe> | ((e: MouseEvent, element: HTMLElement, pswp: PhotoSwipe) => void)} [onClick]
  * @prop {'bar' | 'wrapper'} [appendTo]
+ * @prop {number=} order
  */
 
 class UIElement {

--- a/src/js/ui/ui-element.js
+++ b/src/js/ui/ui-element.js
@@ -1,5 +1,22 @@
 import { createElement } from '../util/util.js';
 
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+
+/**
+ * @typedef {Object} UIElementMarkupProps
+ * @prop {boolean=} isCustomSVG
+ * @prop {string} inner
+ * @prop {string=} outlineID
+ * @prop {number | string} [size]
+ */
+
+/** @typedef {'arrowPrev' | 'arrowNext' | 'close' | 'zoom' | 'counter'} DefaultUIElements */
+
+/** @typedef {string | UIElementMarkupProps} UIElementMarkup */
+
+/**
+ * @param {UIElementMarkup} [htmlData]
+ */
 function addElementHTML(htmlData) {
   if (typeof htmlData === 'string') {
     // Allow developers to provide full svg,
@@ -18,7 +35,8 @@ function addElementHTML(htmlData) {
 
   const svgData = htmlData;
   let out = '<svg aria-hidden="true" class="pswp__icn" viewBox="0 0 %d %d" width="%d" height="%d">';
-  out = out.split('%d').join(svgData.size || 32); // replace all %d with size
+  // replace all %d with size
+  out = out.split('%d').join(/** @type {string} */ (svgData.size || 32));
 
   // Icons may contain outline/shadow,
   // to make it we "clone" base icon shape and add border to it.
@@ -36,22 +54,43 @@ function addElementHTML(htmlData) {
   return out;
 }
 
+/**
+ * @typedef {Object} UIElementData
+ * @prop {DefaultUIElements=} name
+ * @prop {string=} className
+ * @prop {UIElementMarkup} html
+ * @prop {boolean=} isButton
+ * @prop {keyof HTMLElementTagNameMap} [tagName]
+ * @prop {string=} title
+ * @prop {string=} ariaLabel
+ * @prop {(element: HTMLElement, pswp: PhotoSwipe) => void} [onInit]
+ * @prop {Methods<PhotoSwipe> | ((e: MouseEvent, element: HTMLElement, pswp: PhotoSwipe) => void)} [onClick]
+ * @prop {'bar' | 'wrapper'} [appendTo]
+ */
+
 class UIElement {
+  /**
+   * @param {PhotoSwipe} pswp
+   * @param {UIElementData} data
+   */
   constructor(pswp, data) {
     const name = data.name || data.className;
     let elementHTML = data.html;
 
+    // @ts-expect-error lookup only by `data.name` maybe?
     if (pswp.options[name] === false) {
       // exit if element is disabled from options
       return;
     }
 
     // Allow to override SVG icons from options
+    // @ts-expect-error lookup only by `data.name` maybe?
     if (typeof pswp.options[name + 'SVG'] === 'string') {
       // arrowPrevSVG
       // arrowNextSVG
       // closeSVG
       // zoomSVG
+      // @ts-expect-error lookup only by `data.name` maybe?
       elementHTML = pswp.options[name + 'SVG'];
     }
 
@@ -65,22 +104,25 @@ class UIElement {
       className += (data.className || `pswp__${data.name}`);
     }
 
+    /** @type {HTMLElement} */
     let element;
     let tagName = data.isButton ? (data.tagName || 'button') : (data.tagName || 'div');
-    tagName = tagName.toLowerCase();
+    tagName = /** @type {keyof HTMLElementTagNameMap} */ (tagName.toLowerCase());
     element = createElement(className, tagName);
 
     if (data.isButton) {
       // create button element
       element = createElement(className, tagName);
       if (tagName === 'button') {
-        element.type = 'button';
+        /** @type {HTMLButtonElement} */ (element).type = 'button';
       }
 
       let { title } = data;
       const { ariaLabel } = data;
 
+      // @ts-expect-error lookup only by `data.name` maybe?
       if (typeof pswp.options[name + 'Title'] === 'string') {
+        // @ts-expect-error lookup only by `data.name` maybe?
         title = pswp.options[name + 'Title'];
       }
 
@@ -89,7 +131,7 @@ class UIElement {
       }
 
       if (ariaLabel || title) {
-        element.setAttribute('aria-label', ariaLabel || title);
+        /** @type {HTMLElement} */ (element).setAttribute('aria-label', ariaLabel || title);
       }
     }
 
@@ -114,7 +156,7 @@ class UIElement {
     let container;
     if (appendTo === 'bar') {
       if (!pswp.topBar) {
-        pswp.topBar = createElement('pswp__top-bar pswp__hide-on-close', false, pswp.scrollWrap);
+        pswp.topBar = createElement('pswp__top-bar pswp__hide-on-close', 'div', pswp.scrollWrap);
       }
       container = pswp.topBar;
     } else {

--- a/src/js/ui/ui-element.js
+++ b/src/js/ui/ui-element.js
@@ -10,6 +10,21 @@ import { createElement } from '../util/util.js';
  * @prop {number | string} [size]
  */
 
+/**
+ * @typedef {Object} UIElementData
+ * @prop {DefaultUIElements | string} [name]
+ * @prop {string=} className
+ * @prop {UIElementMarkup=} html
+ * @prop {boolean=} isButton
+ * @prop {keyof HTMLElementTagNameMap} [tagName]
+ * @prop {string=} title
+ * @prop {string=} ariaLabel
+ * @prop {(element: HTMLElement, pswp: PhotoSwipe) => void} [onInit]
+ * @prop {Methods<PhotoSwipe> | ((e: MouseEvent, element: HTMLElement, pswp: PhotoSwipe) => void)} [onClick]
+ * @prop {'bar' | 'wrapper' | 'root'} [appendTo]
+ * @prop {number=} order
+ */
+
 /** @typedef {'arrowPrev' | 'arrowNext' | 'close' | 'zoom' | 'counter'} DefaultUIElements */
 
 /** @typedef {string | UIElementMarkupProps} UIElementMarkup */
@@ -53,21 +68,6 @@ function addElementHTML(htmlData) {
 
   return out;
 }
-
-/**
- * @typedef {Object} UIElementData
- * @prop {DefaultUIElements | string} [name]
- * @prop {string=} className
- * @prop {UIElementMarkup=} html
- * @prop {boolean=} isButton
- * @prop {keyof HTMLElementTagNameMap} [tagName]
- * @prop {string=} title
- * @prop {string=} ariaLabel
- * @prop {(element: HTMLElement, pswp: PhotoSwipe) => void} [onInit]
- * @prop {Methods<PhotoSwipe> | ((e: MouseEvent, element: HTMLElement, pswp: PhotoSwipe) => void)} [onClick]
- * @prop {'bar' | 'wrapper'} [appendTo]
- * @prop {number=} order
- */
 
 class UIElement {
   /**

--- a/src/js/ui/ui.js
+++ b/src/js/ui/ui.js
@@ -5,19 +5,32 @@ import zoomButton from './button-zoom.js';
 import { loadingIndicator } from './loading-indicator.js';
 import { counterIndicator } from './counter-indicator.js';
 
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("./ui-element").UIElementData} UIElementData */
+
 /**
  * Set special class on element when image is zoomed.
  *
  * By default it is used to adjust
  * zoom icon and zoom cursor via CSS.
  *
- * @param {Boolean} isZoomedIn
+ * @param {HTMLElement} el
+ * @param {boolean} isZoomedIn
  */
 function setZoomedIn(el, isZoomedIn) {
   el.classList[isZoomedIn ? 'add' : 'remove']('pswp--zoomed-in');
 }
 
 class UI {
+  /** @type {() => void} */
+  updatePreloaderVisibility;
+
+  /** @type {number} */
+  _lastUpdatedZoomLevel;
+
+  /**
+   * @param {PhotoSwipe} pswp
+   */
   constructor(pswp) {
     this.pswp = pswp;
   }
@@ -25,6 +38,7 @@ class UI {
   init() {
     const { pswp } = this;
     this.isRegistered = false;
+    /** @type {UIElementData[]} */
     this.uiElementsData = [
       closeButton,
       arrowPrev,
@@ -42,6 +56,7 @@ class UI {
       return (a.order || 0) - (b.order || 0);
     });
 
+    /** @type {(UIElement | UIElementData)[]} */
     this.items = [];
 
     this.isRegistered = true;
@@ -56,6 +71,9 @@ class UI {
     pswp.on('zoomPanUpdate', () => this._onZoomPanUpdate());
   }
 
+  /**
+   * @param {UIElementData} elementData
+   */
   registerElement(elementData) {
     if (this.isRegistered) {
       this.items.push(

--- a/src/js/util/animations.js
+++ b/src/js/util/animations.js
@@ -18,7 +18,7 @@ import SpringAnimation from './spring-animation.js';
  * @prop {number=} naturalFrequency
  *
  * @prop {(end: number) => void} [onUpdate]
- * @prop {() => void} onComplete
+ * @prop {() => void} [onComplete]
  * @prop {() => void} [onFinish]
  *
  * @prop {string=} transform

--- a/src/js/util/animations.js
+++ b/src/js/util/animations.js
@@ -1,7 +1,7 @@
 import CSSAnimation from './css-animation.js';
 import SpringAnimation from './spring-animation.js';
 
-/** @typedef {SpringAnimation & CSSAnimation} Animation */
+/** @typedef {SpringAnimation | CSSAnimation} Animation */
 
 /**
  * @typedef {Object} AnimationProps
@@ -60,15 +60,12 @@ class Animations {
     /** @type {Animation} */
     let animation;
     if (isSpring) {
-      // @ts-expect-error
       animation = new SpringAnimation(props);
     } else {
-      // @ts-expect-error
       animation = new CSSAnimation(props);
     }
 
     this.activeAnimations.push(animation);
-    // @ts-expect-error TODO: rework this
     animation.onFinish = () => this.stop(animation);
 
     return animation;

--- a/src/js/util/animations.js
+++ b/src/js/util/animations.js
@@ -1,37 +1,82 @@
 import CSSAnimation from './css-animation.js';
 import SpringAnimation from './spring-animation.js';
 
+/** @typedef {SpringAnimation & CSSAnimation} Animation */
+
+/**
+ * @typedef {Object} AnimationProps
+ *
+ * @prop {HTMLElement=} target
+ *
+ * @prop {string=} name
+ *
+ * @prop {number=} start
+ * @prop {number=} end
+ * @prop {number=} duration
+ * @prop {number=} velocity
+ * @prop {number=} dampingRatio
+ * @prop {number=} naturalFrequency
+ *
+ * @prop {(end: number) => void} [onUpdate]
+ * @prop {() => void} onComplete
+ * @prop {() => void} [onFinish]
+ *
+ * @prop {string=} transform
+ * @prop {string=} opacity
+ * @prop {string=} easing
+ *
+ * @prop {boolean=} isPan
+ * @prop {boolean=} isMainScroll
+ */
+
 /**
  * Manages animations
  */
-
 class Animations {
   constructor() {
+    /** @type {Animation[]} */
     this.activeAnimations = [];
   }
 
+  /**
+   * @param {AnimationProps} props
+   */
   startSpring(props) {
     this._start(props, true);
   }
 
+  /**
+   * @param {AnimationProps} props
+   */
   startTransition(props) {
     this._start(props);
   }
 
+  /**
+   * @param {AnimationProps} props
+   * @param {boolean=} isSpring
+   */
   _start(props, isSpring) {
+    /** @type {Animation} */
     let animation;
     if (isSpring) {
+      // @ts-expect-error
       animation = new SpringAnimation(props);
     } else {
+      // @ts-expect-error
       animation = new CSSAnimation(props);
     }
 
     this.activeAnimations.push(animation);
+    // @ts-expect-error TODO: rework this
     animation.onFinish = () => this.stop(animation);
 
     return animation;
   }
 
+  /**
+   * @param {Animation} animation
+   */
   stop(animation) {
     animation.destroy();
     const index = this.activeAnimations.indexOf(animation);

--- a/src/js/util/css-animation.js
+++ b/src/js/util/css-animation.js
@@ -6,8 +6,14 @@ import { setTransitionStyle, removeTransitionStyle } from './util.js';
 
 const DEFAULT_EASING = 'cubic-bezier(.4,0,.22,1)';
 
+/** @typedef {import("./animations").AnimationProps} AnimationProps */
+
 class CSSAnimation {
-  // onComplete can be unpredictable, be careful about current state
+  /**
+   * onComplete can be unpredictable, be careful about current state
+   *
+   * @param {AnimationProps} props
+   */
   constructor(props) {
     this.props = props;
     const {
@@ -50,15 +56,23 @@ class CSSAnimation {
     }, 0);
   }
 
+  /**
+   * @private
+   * @param {TransitionEvent} e
+   */
   _onTransitionEnd(e) {
     if (e.target === this._target) {
       this._finalizeAnimation();
     }
   }
 
+  /**
+   * @private
+   */
   _finalizeAnimation() {
     if (!this._finished) {
       this._finished = true;
+      // @ts-expect-error defined from the outside, maybe it should be defined more explicit?
       this.onFinish();
       if (this._onComplete) {
         this._onComplete();

--- a/src/js/util/css-animation.js
+++ b/src/js/util/css-animation.js
@@ -1,13 +1,12 @@
-/**
- * Runs CSS transition.
- */
-
 import { setTransitionStyle, removeTransitionStyle } from './util.js';
 
 const DEFAULT_EASING = 'cubic-bezier(.4,0,.22,1)';
 
 /** @typedef {import("./animations").AnimationProps} AnimationProps */
 
+/**
+ * Runs CSS transition.
+ */
 class CSSAnimation {
   /** @type {() => void} */
   onFinish;

--- a/src/js/util/css-animation.js
+++ b/src/js/util/css-animation.js
@@ -9,6 +9,9 @@ const DEFAULT_EASING = 'cubic-bezier(.4,0,.22,1)';
 /** @typedef {import("./animations").AnimationProps} AnimationProps */
 
 class CSSAnimation {
+  /** @type {() => void} */
+  onFinish;
+
   /**
    * onComplete can be unpredictable, be careful about current state
    *
@@ -32,12 +35,15 @@ class CSSAnimation {
     const prop = transform ? 'transform' : 'opacity';
     const propValue = props[prop];
 
+    /** @private */
     this._target = target;
+    /** @private */
     this._onComplete = onComplete;
 
     duration = duration || 333;
     easing = easing || DEFAULT_EASING;
 
+    /** @private */
     this._onTransitionEnd = this._onTransitionEnd.bind(this);
 
     // Using timeout hack to make sure that animation
@@ -46,6 +52,7 @@ class CSSAnimation {
     // https://drafts.csswg.org/css-transitions/#starting
     //
     // ¯\_(ツ)_/¯
+    /** @private */
     this._firstFrameTimeout = setTimeout(() => {
       setTransitionStyle(target, prop, duration, easing);
       this._firstFrameTimeout = setTimeout(() => {
@@ -72,7 +79,6 @@ class CSSAnimation {
   _finalizeAnimation() {
     if (!this._finished) {
       this._finished = true;
-      // @ts-expect-error defined from the outside, maybe it should be defined more explicit?
       this.onFinish();
       if (this._onComplete) {
         this._onComplete();

--- a/src/js/util/dom-events.js
+++ b/src/js/util/dom-events.js
@@ -15,7 +15,7 @@ try {
  * @typedef {Object} PoolItem
  * @prop {HTMLElement | Window | Document} target
  * @prop {string} type
- * @prop {() => void} listener
+ * @prop {(e: any) => void} listener
  * @prop {boolean} passive
  */
 
@@ -33,7 +33,7 @@ class DOMEvents {
    *
    * @param {HTMLElement | Window | Document} target
    * @param {string} type Can be multiple, separated by space.
-   * @param {() => void} listener
+   * @param {(e: any) => void} listener
    * @param {boolean=} passive
    */
   add(target, type, listener, passive) {
@@ -45,7 +45,7 @@ class DOMEvents {
    *
    * @param {HTMLElement | Window | Document} target
    * @param {string} type
-   * @param {() => void} listener
+   * @param {(e: any) => void} listener
    * @param {boolean=} passive
    */
   remove(target, type, listener, passive) {
@@ -74,7 +74,7 @@ class DOMEvents {
    *
    * @param {HTMLElement | Window | Document} target
    * @param {string} type
-   * @param {() => void} listener
+   * @param {(e: any) => void} listener
    * @param {boolean} passive
    * @param {boolean=} unbind Whether the event should be added or removed
    * @param {boolean=} skipPool Whether events pool should be skipped

--- a/src/js/util/dom-events.js
+++ b/src/js/util/dom-events.js
@@ -10,18 +10,31 @@ try {
 } catch (e) {}
 /* eslint-enable */
 
+
+/**
+ * @typedef {Object} PoolItem
+ * @prop {HTMLElement | Window | Document} target
+ * @prop {string} type
+ * @prop {() => void} listener
+ * @prop {boolean} passive
+ */
+
 class DOMEvents {
   constructor() {
+    /**
+     * @type {PoolItem[]}
+     * @private
+     */
     this._pool = [];
   }
 
   /**
    * Adds event listeners
    *
-   * @param {DOMElement} target
-   * @param {String} type Can be multiple, separated by space.
-   * @param {Function} listener
-   * @param {Boolean} passive
+   * @param {HTMLElement | Window | Document} target
+   * @param {string} type Can be multiple, separated by space.
+   * @param {() => void} listener
+   * @param {boolean=} passive
    */
   add(target, type, listener, passive) {
     this._toggleListener(target, type, listener, passive);
@@ -30,10 +43,10 @@ class DOMEvents {
   /**
    * Removes event listeners
    *
-   * @param {DOMElement} target
-   * @param {String} type
-   * @param {Function} listener
-   * @param {Boolean} passive
+   * @param {HTMLElement | Window | Document} target
+   * @param {string} type
+   * @param {() => void} listener
+   * @param {boolean=} passive
    */
   remove(target, type, listener, passive) {
     this._toggleListener(target, type, listener, passive, true);
@@ -59,21 +72,21 @@ class DOMEvents {
   /**
    * Adds or removes event
    *
-   * @param {DOMElement} target
-   * @param {String} type
-   * @param {Function} listener
-   * @param {Boolean} passive
-   * @param {Boolean} unbind Whether the event should be added or removed
-   * @param {Boolean} skipPool Whether events pool should be skipped
+   * @param {HTMLElement | Window | Document} target
+   * @param {string} type
+   * @param {() => void} listener
+   * @param {boolean} passive
+   * @param {boolean=} unbind Whether the event should be added or removed
+   * @param {boolean=} skipPool Whether events pool should be skipped
    */
   _toggleListener(target, type, listener, passive, unbind, skipPool) {
     if (!target) {
       return;
     }
 
-    const methodName = (unbind ? 'remove' : 'add') + 'EventListener';
-    type = type.split(' ');
-    type.forEach((eType) => {
+    const methodName = unbind ? 'removeEventListener' : 'addEventListener';
+    const types = type.split(' ');
+    types.forEach((eType) => {
       if (eType) {
         // Events pool is used to easily unbind all events when PhotoSwipe is closed,
         // so developer doesn't need to do this manually

--- a/src/js/util/spring-animation.js
+++ b/src/js/util/spring-animation.js
@@ -3,6 +3,9 @@ import SpringEaser from './spring-easer.js';
 /** @typedef {import("./animations").AnimationProps} AnimationProps */
 
 class SpringAnimation {
+  /** @type {() => void} */
+  onFinish;
+
   /**
    * @param {AnimationProps} props
    */
@@ -37,7 +40,6 @@ class SpringAnimation {
           if (onComplete) {
             onComplete();
           }
-          // @ts-expect-error defined from the outside, maybe it should be defined more explicit?
           this.onFinish();
         } else {
           prevTime = Date.now();

--- a/src/js/util/spring-animation.js
+++ b/src/js/util/spring-animation.js
@@ -1,6 +1,11 @@
 import SpringEaser from './spring-easer.js';
 
+/** @typedef {import("./animations").AnimationProps} AnimationProps */
+
 class SpringAnimation {
+  /**
+   * @param {AnimationProps} props
+   */
   constructor(props) {
     this.props = props;
 
@@ -32,6 +37,7 @@ class SpringAnimation {
           if (onComplete) {
             onComplete();
           }
+          // @ts-expect-error defined from the outside, maybe it should be defined more explicit?
           this.onFinish();
         } else {
           prevTime = Date.now();

--- a/src/js/util/spring-easer.js
+++ b/src/js/util/spring-easer.js
@@ -7,17 +7,19 @@ const DEFAULT_DAMPING_RATIO = 0.75;
 
 class SpringEaser {
   /**
-   * @param {Number} initialVelocity Initial velocity, px per ms.
+   * @param {number} initialVelocity Initial velocity, px per ms.
    *
-   * @param {Number} dampingRatio Determines how bouncy animation will be.
-   *                              From 0 to 1, 0 - always overshoot, 1 - do not overshoot.
-   *                              "overshoot" refers to part of animation that
-   *                              goes beyond the final value.
+   * @param {number} dampingRatio
+   * Determines how bouncy animation will be.
+   * From 0 to 1, 0 - always overshoot, 1 - do not overshoot.
+   * "overshoot" refers to part of animation that
+   * goes beyond the final value.
    *
-   * @param {Number} naturalFrequency Determines how fast animation will slow down.
-   *                                  The higher value - the stiffer the transition will be,
-   *                                  and the faster it will slow down.
-   *                                  Recommended value from 10 to 50
+   * @param {number} naturalFrequency
+   * Determines how fast animation will slow down.
+   * The higher value - the stiffer the transition will be,
+   * and the faster it will slow down.
+   * Recommended value from 10 to 50
    */
   constructor(initialVelocity, dampingRatio, naturalFrequency) {
     this.velocity = initialVelocity * 1000; // convert to "pixels per second"
@@ -35,10 +37,10 @@ class SpringEaser {
   }
 
   /**
-   * @param {Number} deltaPosition Difference between current and end position of the animation
-   * @param {Number} deltaTime Frame duration in milliseconds
+   * @param {number} deltaPosition Difference between current and end position of the animation
+   * @param {number} deltaTime Frame duration in milliseconds
    *
-   * @returns {Number} Displacement, relative to the end position.
+   * @returns {number} Displacement, relative to the end position.
    */
   easeFrame(deltaPosition, deltaTime) {
     // Inspired by Apple Webkit and Android spring function implementation

--- a/src/js/util/spring-easer.js
+++ b/src/js/util/spring-easer.js
@@ -1,10 +1,9 @@
-/**
- * Spring easing helper
- */
-
 const DEFAULT_NATURAL_FREQUENCY = 12;
 const DEFAULT_DAMPING_RATIO = 0.75;
 
+/**
+ * Spring easing helper
+ */
 class SpringEaser {
   /**
    * @param {number} initialVelocity Initial velocity, px per ms.

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -2,8 +2,8 @@
   * Creates element and optionally appends it to another.
   *
   * @param {String} className
-  * @param {String|NULL} tagName
-  * @param {Element|NULL} appendToEl
+  * @param {String | null} tagName
+  * @param {HTMLElement | null} appendToEl
   */
 export function createElement(className, tagName, appendToEl) {
   const el = document.createElement(tagName || 'div');
@@ -16,6 +16,12 @@ export function createElement(className, tagName, appendToEl) {
   return el;
 }
 
+/** @typedef {{ x: number; y: number; id?: string }} Point */
+
+/**
+ * @param {Point} p1
+ * @param {Point} p2
+ */
 export function equalizePoints(p1, p2) {
   p1.x = p2.x;
   p1.y = p2.y;
@@ -25,7 +31,9 @@ export function equalizePoints(p1, p2) {
   return p1;
 }
 
-
+/**
+ * @param {Point} p
+ */
 export function roundPoint(p) {
   p.x = Math.round(p.x);
   p.y = Math.round(p.y);
@@ -34,8 +42,8 @@ export function roundPoint(p) {
 /**
  * Returns distance between two points.
  *
- * @param {Object} p1 Point
- * @param {Object} p2 Point
+ * @param {Point} p1
+ * @param {Point} p2
  */
 export function getDistanceBetween(p1, p2) {
   const x = Math.abs(p1.x - p2.x);
@@ -46,8 +54,8 @@ export function getDistanceBetween(p1, p2) {
 /**
  * Whether X and Y positions of points are qual
  *
- * @param {Object} p1
- * @param {Object} p2
+ * @param {Point} p1
+ * @param {Point} p2
  */
 export function pointsEqual(p1, p2) {
   return p1.x === p2.x && p1.y === p2.y;
@@ -56,9 +64,9 @@ export function pointsEqual(p1, p2) {
 /**
  * The float result between the min and max values.
  *
- * @param {Number} val
- * @param {Number} min
- * @param {Number} max
+ * @param {number} val
+ * @param {number} min
+ * @param {number} max
  */
 export function clamp(val, min, max) {
   return Math.min(Math.max(val, min), max);
@@ -67,9 +75,9 @@ export function clamp(val, min, max) {
 /**
  * Get transform string
  *
- * @param {Number} x
- * @param {Number|null} y
- * @param {Number|null} scale
+ * @param {number} x
+ * @param {number | null} y
+ * @param {number | null} scale
  */
 export function toTransformString(x, y, scale) {
   let propValue = 'translate3d('
@@ -88,10 +96,10 @@ export function toTransformString(x, y, scale) {
 /**
  * Apply transform:translate(x, y) scale(scale) to element
  *
- * @param {DOMElement} el
- * @param {Number} x
- * @param {Number|null} y
- * @param {Number|null} scale
+ * @param {HTMLElement} el
+ * @param {number} x
+ * @param {number | null} y
+ * @param {number | null} scale
  */
 export function setTransform(el, x, y, scale) {
   el.style.transform = toTransformString(x, y, scale);
@@ -102,10 +110,10 @@ const defaultCSSEasing = 'cubic-bezier(.4,0,.22,1)';
 /**
  * Apply CSS transition to element
  *
- * @param {Element} el
- * @param {String} prop CSS property to animate
- * @param {Number} duration in ms
- * @param {String|NULL} ease CSS easing function
+ * @param {HTMLElement} el
+ * @param {string=} prop CSS property to animate
+ * @param {number=} duration in ms
+ * @param {string | null=} ease CSS easing function
  */
 export function setTransitionStyle(el, prop, duration, ease) {
   // inOut: 'cubic-bezier(.4, 0, .22, 1)', // for "toggle state" transitions
@@ -118,16 +126,27 @@ export function setTransitionStyle(el, prop, duration, ease) {
 
 /**
  * Apply width and height CSS properties to element
+ *
+ * @param {HTMLElement} el
+ * @param {string | number} w
+ * @param {string | number} h
  */
 export function setWidthHeight(el, w, h) {
   el.style.width = (typeof w === 'number') ? (w + 'px') : w;
   el.style.height = (typeof h === 'number') ? (h + 'px') : h;
 }
 
+/**
+ * @param {HTMLElement} el
+ */
 export function removeTransitionStyle(el) {
   setTransitionStyle(el);
 }
 
+/**
+ * @param {HTMLImageElement} img
+ * @returns {Promise<HTMLImageElement | void>}
+ */
 export function decodeImage(img) {
   if ('decode' in img) {
     return img.decode();
@@ -155,7 +174,7 @@ export const LOAD_STATE = {
  * Check if click or keydown event was dispatched
  * with a special key or via mouse wheel.
  *
- * @param {Event} e
+ * @param {PointerEvent} e
  */
 export function specialKeyUsed(e) {
   if (e.which === 2 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
@@ -166,12 +185,13 @@ export function specialKeyUsed(e) {
 /**
  * Parse `gallery` or `children` options.
  *
- * @param {Element|NodeList|String} option
- * @param {String|null} legacySelector
- * @param {Element|null} parent
- * @returns Element[]
+ * @param {HTMLElement | NodeListOf<HTMLElement> | string} option
+ * @param {string | null} legacySelector
+ * @param {HTMLElement | Document | null=} parent
+ * @returns HTMLElement[]
  */
 export function getElementsFromOption(option, legacySelector, parent = document) {
+  /** @type {HTMLElement[]} */
   let elements = [];
 
   if (option instanceof Element) {
@@ -191,8 +211,7 @@ export function getElementsFromOption(option, legacySelector, parent = document)
 /**
  * Check if variable is PhotoSwipe class
  *
- * @param {*} fn
- * @returns Boolean
+ * @param {any} fn
  */
 export function isPswpClass(fn) {
   return typeof fn === 'function'

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -181,7 +181,7 @@ export const LOAD_STATE = {
  * Check if click or keydown event was dispatched
  * with a special key or via mouse wheel.
  *
- * @param {KeyboardEvent} e
+ * @param {MouseEvent | KeyboardEvent} e
  */
 export function specialKeyUsed(e) {
   if (e.which === 2 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -1,14 +1,20 @@
 /** @typedef {import("../photoswipe").Point} Point */
 
+/** @typedef {undefined | null | false | '' | 0} Falsy */
+
 /**
-  * Creates element and optionally appends it to another.
-  *
-  * @param {String} className
-  * @param {String | false} [tagName]
-  * @param {HTMLElement=} appendToEl
-  */
+ * Shoud be done using overloading
+ * but it's not supported by TS-in-JSDoc currently
+ * https://github.com/microsoft/TypeScript/issues/25590
+ */
+/**
+ * @template {keyof HTMLElementTagNameMap} T
+ * @param {string=} className
+ * @param {T | Falsy} [tagName]
+ * @param {HTMLElement=} appendToEl
+ */
 export function createElement(className, tagName, appendToEl) {
-  const el = document.createElement(tagName || 'div');
+  const el = /** @type {HTMLElementTagNameMap[T]} */ (document.createElement(tagName || 'div'));
   if (className) {
     el.className = className;
   }

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -1,26 +1,25 @@
 /** @typedef {import("../photoswipe").Point} Point */
 
 /** @typedef {undefined | null | false | '' | 0} Falsy */
+/** @typedef {keyof HTMLElementTagNameMap} HTMLElementTagName */
 
 /**
- * Shoud be done using overloading
- * but it's not supported by TS-in-JSDoc currently
- * https://github.com/microsoft/TypeScript/issues/25590
- */
-/**
- * @template {keyof HTMLElementTagNameMap} T
+ * @template {HTMLElementTagName | Falsy} [T="div"]
+ * @template {Node | undefined} [NodeToAppendElementTo=undefined]
  * @param {string=} className
- * @param {T | Falsy} [tagName]
- * @param {HTMLElement=} appendToEl
+ * @param {T=} [tagName]
+ * @param {NodeToAppendElementTo=} appendToEl
+ * @returns {T extends HTMLElementTagName ? HTMLElementTagNameMap[T] : HTMLElementTagNameMap['div']}
  */
 export function createElement(className, tagName, appendToEl) {
-  const el = /** @type {HTMLElementTagNameMap[T]} */ (document.createElement(tagName || 'div'));
+  const el = document.createElement(tagName || 'div');
   if (className) {
     el.className = className;
   }
   if (appendToEl) {
     appendToEl.appendChild(el);
   }
+  // @ts-expect-error
   return el;
 }
 

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -1,9 +1,11 @@
+/** @typedef {import("../photoswipe").Point} Point */
+
 /**
   * Creates element and optionally appends it to another.
   *
   * @param {String} className
-  * @param {String | null} tagName
-  * @param {HTMLElement | null} appendToEl
+  * @param {String | false} [tagName]
+  * @param {HTMLElement=} appendToEl
   */
 export function createElement(className, tagName, appendToEl) {
   const el = document.createElement(tagName || 'div');
@@ -15,8 +17,6 @@ export function createElement(className, tagName, appendToEl) {
   }
   return el;
 }
-
-/** @typedef {{ x: number; y: number; id?: string }} Point */
 
 /**
  * @param {Point} p1
@@ -76,8 +76,8 @@ export function clamp(val, min, max) {
  * Get transform string
  *
  * @param {number} x
- * @param {number | null} y
- * @param {number | null} scale
+ * @param {number=} y
+ * @param {number=} scale
  */
 export function toTransformString(x, y, scale) {
   let propValue = 'translate3d('
@@ -98,8 +98,8 @@ export function toTransformString(x, y, scale) {
  *
  * @param {HTMLElement} el
  * @param {number} x
- * @param {number | null} y
- * @param {number | null} scale
+ * @param {number=} y
+ * @param {number=} scale
  */
 export function setTransform(el, x, y, scale) {
   el.style.transform = toTransformString(x, y, scale);
@@ -113,7 +113,7 @@ const defaultCSSEasing = 'cubic-bezier(.4,0,.22,1)';
  * @param {HTMLElement} el
  * @param {string=} prop CSS property to animate
  * @param {number=} duration in ms
- * @param {string | null=} ease CSS easing function
+ * @param {string=} ease CSS easing function
  */
 export function setTransitionStyle(el, prop, duration, ease) {
   // inOut: 'cubic-bezier(.4, 0, .22, 1)', // for "toggle state" transitions
@@ -186,8 +186,8 @@ export function specialKeyUsed(e) {
  * Parse `gallery` or `children` options.
  *
  * @param {HTMLElement | NodeListOf<HTMLElement> | string} option
- * @param {string | null} legacySelector
- * @param {HTMLElement | Document | null=} parent
+ * @param {string=} legacySelector
+ * @param {HTMLElement | Document} [parent]
  * @returns HTMLElement[]
  */
 export function getElementsFromOption(option, legacySelector, parent = document) {

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -167,6 +167,8 @@ export function decodeImage(img) {
   });
 }
 
+/** @typedef {LOAD_STATE[keyof LOAD_STATE]} LoadState */
+/** @type {{ IDLE: 'idle'; LOADING: 'loading'; LOADED: 'loaded'; ERROR: 'error' }} */
 export const LOAD_STATE = {
   IDLE: 'idle',
   LOADING: 'loading',
@@ -179,7 +181,7 @@ export const LOAD_STATE = {
  * Check if click or keydown event was dispatched
  * with a special key or via mouse wheel.
  *
- * @param {PointerEvent} e
+ * @param {KeyboardEvent} e
  */
 export function specialKeyUsed(e) {
   if (e.which === 2 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {

--- a/src/js/util/viewport-size.js
+++ b/src/js/util/viewport-size.js
@@ -1,3 +1,11 @@
+/** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
+/** @typedef {import("../photoswipe").PhotoSwipeItem} PhotoSwipeItem */
+/** @typedef {import("../photoswipe").default} PhotoSwipe */
+
+/**
+ * @param {PhotoSwipeOptions} options
+ * @param {PhotoSwipe} pswp
+ */
 export function getViewportSize(options, pswp) {
   if (options.getViewportSizeFn) {
     const newViewportSize = options.getViewportSizeFn(options, pswp);
@@ -45,14 +53,15 @@ export function getViewportSize(options, pswp) {
  * paddingTop: 0,
  * paddingBottom: 0,
  *
- * @param {String}  prop 'left', 'top', 'bottom', 'right'
- * @param {Object}  options PhotoSwipe options
- * @param {Object}  viewportSize PhotoSwipe viewport size, for example: { x:800, y:600 }
- * @param {Object}  itemData Data about the slide
- * @param {Integer} index Slide index
- * @returns {Number}
+ * @param {'left' | 'top' | 'bottom' | 'right'} prop
+ * @param {PhotoSwipeOptions} options PhotoSwipe options
+ * @param {{ x: number; y: number }} viewportSize PhotoSwipe viewport size, for example: { x:800, y:600 }
+ * @param {PhotoSwipeItem} itemData Data about the slide
+ * @param {number} index Slide index
+ * @returns {number}
  */
 export function parsePaddingOption(prop, options, viewportSize, itemData, index) {
+  /** @type {number} */
   let paddingValue;
 
   if (options.paddingFn) {
@@ -61,7 +70,9 @@ export function parsePaddingOption(prop, options, viewportSize, itemData, index)
     paddingValue = options.padding[prop];
   } else {
     const legacyPropName = 'padding' + prop[0].toUpperCase() + prop.slice(1);
+    // @ts-expect-error
     if (options[legacyPropName]) {
+      // @ts-expect-error
       paddingValue = options[legacyPropName];
     }
   }
@@ -69,7 +80,12 @@ export function parsePaddingOption(prop, options, viewportSize, itemData, index)
   return paddingValue || 0;
 }
 
-
+/**
+ * @param {PhotoSwipeOptions} options
+ * @param {{ x: number; y: number }} viewportSize
+ * @param {PhotoSwipeItem} itemData
+ * @param {number} index
+ */
 export function getPanAreaSize(options, viewportSize, itemData, index) {
   return {
     x: viewportSize.x

--- a/src/js/util/viewport-size.js
+++ b/src/js/util/viewport-size.js
@@ -1,6 +1,6 @@
 /** @typedef {import("../photoswipe").PhotoSwipeOptions} PhotoSwipeOptions */
-/** @typedef {import("../photoswipe").PhotoSwipeItem} PhotoSwipeItem */
 /** @typedef {import("../photoswipe").default} PhotoSwipe */
+/** @typedef {import("../slide/slide").SlideData} SlideData */
 
 /**
  * @param {PhotoSwipeOptions} options
@@ -55,8 +55,8 @@ export function getViewportSize(options, pswp) {
  *
  * @param {'left' | 'top' | 'bottom' | 'right'} prop
  * @param {PhotoSwipeOptions} options PhotoSwipe options
- * @param {{ x: number; y: number }} viewportSize PhotoSwipe viewport size, for example: { x:800, y:600 }
- * @param {PhotoSwipeItem} itemData Data about the slide
+ * @param {{ x?: number; y?: number }} viewportSize PhotoSwipe viewport size, for example: { x:800, y:600 }
+ * @param {SlideData} itemData Data about the slide
  * @param {number} index Slide index
  * @returns {number}
  */
@@ -82,8 +82,8 @@ export function parsePaddingOption(prop, options, viewportSize, itemData, index)
 
 /**
  * @param {PhotoSwipeOptions} options
- * @param {{ x: number; y: number }} viewportSize
- * @param {PhotoSwipeItem} itemData
+ * @param {{ x?: number; y?: number }} viewportSize
+ * @param {SlideData} itemData
  * @param {number} index
  */
 export function getPanAreaSize(options, viewportSize, itemData, index) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "strictNullChecks": false,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "allowJs": true,
+    "checkJs": true,
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "outDir": "dist",
+    "outDir": "types",
     "declaration": true,
+    "emitDeclarationOnly": true,
     "strict": true,
     "strictNullChecks": false,
     "skipLibCheck": true,
@@ -9,6 +10,7 @@
     "allowJs": true,
     "checkJs": true,
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/js/**/*"
+  ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "checkJs": true,
   },
   "include": [
+    "global.d.ts",
     "declarations.d.ts",
     "src/js/**/*"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "outDir": "types",
+    "outDir": "dist/types",
     "declaration": true,
     "emitDeclarationOnly": true,
     "strict": true,
@@ -12,7 +12,6 @@
   },
   "include": [
     "global.d.ts",
-    "declarations.d.ts",
     "src/js/**/*"
   ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "checkJs": true,
   },
   "include": [
+    "declarations.d.ts",
     "src/js/**/*"
   ],
 }


### PR DESCRIPTION
This PR introduces type definitions for the PhotoSwipe. It was a bit harder to do and took much more time than I first assumed. Not everything went as planned, because of some JSDoc TS limitations, but it's finally here!

### What has been done?
- The entire codebase was covered with type definitions.
- Set up `.d.ts` files generation to `dist/types` dir, in `build-and-minify-js` npm script.
- Entry points for types were referenced in the `package.json` in the [actual way](https://github.com/microsoft/TypeScript/issues/33079). Also, a fallback for older TS versions was provided.
- The JS code was modified slightly:
  - Added some class properties.
  - Provided strings instead of numbers or cast them where it's expected.
  - Property lookup using `in` operator in some places, for type guards.
- Some minor chores that affect the entire project:
  - `package-lock.json` updated from `v1` to `v2` (it was done automatically, by running `npm install` with npm v8.5.5).
  - Added `.editorconfig` [file](https://editorconfig.org/) to maintain consistency across different configuration files.
  - Slightly increased value for `max-len`eslint rule (only for comments).
  - Added `.eslintignore` file.

### How will these changes improve UX?
- Library users can use it in TypeScript projects.
- In non-TS projects, users will get intellisense to work in their editors (code completion, type hints, etc.).

### How will these changes improve DX?
- Almost complete type-checking for the entire codebase, all functions, classes, events and filters.
- It will become easier to understand how the code works, what arguments are expected, etc.

### What can be fixed in the future?
- Resolve `// @ts-expect-error` comments.
- Exclude build artifacts from git.
- Implement display of the comments for events/filters in the editors.
- Rewrite all in TS maybe? It's supposed to be pretty easy from this point.
- Auto-generate docs from type definitions/comments?
- Try to differentiate PhotoSwipe and PhotoSwipeLightbox options, if it makes sense.
- Infer type for `instance.options.dataSource` from provided `dataSource` option.
- Define type for `onInit(el)` of `registerElement` based on provided `tagName`.
- Add ability to describe `SlideData` additional props more strictly from the outside somehow.
- Add description to all exposed options/methods.
- Add some tests for types.

I excluded build artifacts from this PR for an easier review process. You can see it here: https://github.com/irudoy/PhotoSwipe/tree/types-built/dist/types

Fixes #1888