### PR TITLE
changed innerHTML to innerText to preserve Trusted Types

### DIFF
--- a/src/js/slide/slide.js
+++ b/src/js/slide/slide.js
@@ -106,7 +106,7 @@ class Slide {
 
     // Slide appended to DOM
     if (!this.data) {
-      this.holderElement.innerHTML = '';
+      this.holderElement.innerText = '';
       return;
     }
 
@@ -118,7 +118,7 @@ class Slide {
     this.appendHeavy();
     this.updateContentSize();
 
-    this.holderElement.innerHTML = '';
+    this.holderElement.innerText = '';
     this.holderElement.appendChild(this.container);
 
     this.zoomAndPanToInitial();


### PR DESCRIPTION
I'm working with @tosmolka, and this is a follow-up on issue  #1841. I've checked the file for Trusted Types violation and so far corrected one file only by changing innerHTML to innerText. There are other violations in _ui-element.js_:144 but these will be for a more complex rewrite, and I'll be working on that following days. As for now, we would like to get feedback from you on our approach so we know that this is the way we should go. 

