### PR TITLE
docs upd: fix broken urls

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -173,8 +173,8 @@ button.pswp__button--test-button {
 
 </PswpCodePreview>
 
-Alternatively, you may omit `dataSource` option entirely and use filters to supply data and number of items, example on the [Data Sources page]/(data-sources#dynamically-generated-data).
+Alternatively, you may omit `dataSource` option entirely and use filters to supply data and number of items, example on the [Data Sources page](/data-sources#dynamically-generated-data).
 
 ## UI
 
-Refer to [Styling]/(styling) page on how to adjust the UI (add buttons, modify icons, etc).
+Refer to [Styling](/styling) page on how to adjust the UI (add buttons, modify icons, etc).


### PR DESCRIPTION
This PR fixes broken URLs on the Methods page https://photoswipe.com/methods/