### PR TITLE
fix(types): change types of children & gallery options according to docs

### DIFF
--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -52,6 +52,10 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {PhotoSwipeModule | Promise<PhotoSwipeModule> | (() => Promise<PhotoSwipeModule>)} PhotoSwipeModuleOption */
 
 /**
+ * @typedef {string | NodeListOf<HTMLElement> | HTMLElement[] | HTMLElement} ElementProvider
+ */
+
+/**
  * @typedef {Object} PhotoSwipeOptions https://photoswipe.com/options/
  *
  * @prop {DataSource=} dataSource
@@ -208,9 +212,9 @@ import ContentLoader from './slide/loader.js';
  * @prop {PhotoSwipeModuleOption} [pswpModule]
  * @prop {() => Promise<any>} [openPromise]
  * @prop {boolean=} preloadFirstSlide
- * @prop {string=} gallery
+ * @prop {ElementProvider=} gallery
  * @prop {string=} gallerySelector
- * @prop {string=} children
+ * @prop {ElementProvider=} children
  * @prop {string=} childSelector
  * @prop {string | false} [thumbSelector]
  */

--- a/src/js/util/util.js
+++ b/src/js/util/util.js
@@ -192,7 +192,7 @@ export function specialKeyUsed(e) {
 /**
  * Parse `gallery` or `children` options.
  *
- * @param {HTMLElement | NodeListOf<HTMLElement> | string} option
+ * @param {import('../photoswipe.js').ElementProvider} option
  * @param {string=} legacySelector
  * @param {HTMLElement | Document} [parent]
  * @returns HTMLElement[]


### PR DESCRIPTION
According to the docs the [`children` and `gallery` options](https://photoswipe.com/options/#children) should also accept `NodeList`, `HTMLElement` `HTMLElement[]` besides a CSS-Selector. The current types don't reflect that, as they require you to pass a CSS-Selector as a string. 

![image](https://user-images.githubusercontent.com/2717384/197511850-92eff147-7abc-45f5-a9e4-5399c0e12505.png)

This PR adds a new type `ElementProvider` which encompasses those types and gets used in the types of the `children` & `gallery` options.