### PR TITLE
fix: add missing type parameter constraints

### DIFF
--- a/src/js/gestures/tap-handler.js
+++ b/src/js/gestures/tap-handler.js
@@ -1,5 +1,6 @@
 /**
- * @template T, P
+ * @template {string} T
+ * @template {string} P
  * @typedef {import('../types.js').AddPostfix<T, P>} AddPostfix<T, P>
  */
 

--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -21,7 +21,7 @@ import { lazyLoadSlide } from '../slide/loader.js';
 /** @typedef {import('../core/eventable.js').PhotoSwipeFiltersMap} PhotoSwipeFiltersMap */
 
 /**
- * @template T
+ * @template {keyof PhotoSwipeEventsMap} T
  * @typedef {import('../core/eventable.js').EventCallback<T>} EventCallback<T>
  */
 

--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -33,11 +33,11 @@ import ContentLoader from './slide/loader.js';
 /** @typedef {import('./core/eventable.js').PhotoSwipeFiltersMap} PhotoSwipeFiltersMap */
 /** @typedef {import('./slide/get-thumb-bounds').Bounds} Bounds */
 /**
- * @template T
+ * @template {keyof PhotoSwipeEventsMap} T
  * @typedef {import('./core/eventable.js').EventCallback<T>} EventCallback<T>
  */
 /**
- * @template T
+ * @template {keyof PhotoSwipeEventsMap} T
  * @typedef {import('./core/eventable.js').AugmentedEvent<T>} AugmentedEvent<T>
  */
 


### PR DESCRIPTION
There's an issue with the type declarations in newer versions of TypeScript where the checking is a bit stricter. These typedefs need their type parameters constrained, or you will see the following errors:

```
node_modules/photoswipe/dist/types/gestures/tap-handler.d.ts:5:65 - error TS2344: Type 'T' does not satisfy the constraint 'string'.

5 export type AddPostfix<T, P> = import('../types.js').AddPostfix<T, P>;
                                                                  ~

  node_modules/photoswipe/dist/types/gestures/tap-handler.d.ts:5:24
    5 export type AddPostfix<T, P> = import('../types.js').AddPostfix<T, P>;
                             ~
    This type parameter might need an `extends string` constraint.

node_modules/photoswipe/dist/types/lightbox/lightbox.d.ts:16:77 - error TS2344: Type 'T' does not satisfy the constraint 'keyof PhotoSwipeEventsMap'.

16 export type EventCallback<T> = import('../core/eventable.js').EventCallback<T>;
                                                                               ~

  node_modules/photoswipe/dist/types/lightbox/lightbox.d.ts:16:27
    16 export type EventCallback<T> = import('../core/eventable.js').EventCallback<T>;
                                 ~
    This type parameter might need an `extends keyof PhotoSwipeEventsMap` constraint.

node_modules/photoswipe/dist/types/photoswipe.d.ts:16:76 - error TS2344: Type 'T' does not satisfy the constraint 'keyof PhotoSwipeEventsMap'.

16 export type EventCallback<T> = import('./core/eventable.js').EventCallback<T>;
                                                                              ~

  node_modules/photoswipe/dist/types/photoswipe.d.ts:16:27
    16 export type EventCallback<T> = import('./core/eventable.js').EventCallback<T>;
                                 ~
    This type parameter might need an `extends keyof PhotoSwipeEventsMap` constraint.

node_modules/photoswipe/dist/types/photoswipe.d.ts:20:78 - error TS2344: Type 'T' does not satisfy the constraint 'keyof PhotoSwipeEventsMap'.

20 export type AugmentedEvent<T> = import('./core/eventable.js').AugmentedEvent<T>;
                                                                                ~

  node_modules/photoswipe/dist/types/photoswipe.d.ts:20:28
    20 export type AugmentedEvent<T> = import('./core/eventable.js').AugmentedEvent<T>;
                                  ~
    This type parameter might need an `extends keyof PhotoSwipeEventsMap` constraint.
```
