### PR TITLE
fix: make `dataSource` param optional in `loadAndOpen`

### DIFF
--- a/src/js/lightbox/lightbox.js
+++ b/src/js/lightbox/lightbox.js
@@ -145,7 +145,7 @@ class PhotoSwipeLightbox extends PhotoSwipeBase {
    * Load and open PhotoSwipe
    *
    * @param {number} index
-   * @param {DataSource} dataSource
+   * @param {DataSource} [dataSource]
    * @param {Point | null} [initialPoint]
    * @returns {boolean}
    */


### PR DESCRIPTION
The parameter `dataSource` is set as required, however in the [docs](https://photoswipe.com/methods/#photoswipelightbox-methods) it's mentioned has optional.

It doesn't make sense to be required since the dataSource is not used in `loadAndOpen`, it's just passed to the `preload` method, which has `dataSource` as optional.

Mentioned in this issue - https://github.com/dimsemenov/PhotoSwipe/issues/2026.