### PR TITLE
Remove restriction of typesVersion to 4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "./style.css": "./dist/photoswipe.css"
   },
   "typesVersions": {
-    "<4.7": {
+    "*": {
       "lightbox": [
         "dist/types/lightbox/lightbox.d.ts"
       ]


### PR DESCRIPTION
Newer versions of TypeScript would not pick up the types when importing from `photoswipe/lightbox` as the types were restricted to version 4.7 or lower.

The types works perfectly fine with newer versions of TS, so by simply removing the restriction everything works as expected.

fixes dimsemenov/PhotoSwipe#2029