### PR TITLE
Add aria-modal to improve a11y

### DIFF
--- a/src/js/photoswipe.js
+++ b/src/js/photoswipe.js
@@ -735,6 +735,7 @@ class PhotoSwipe extends PhotoSwipeBase {
     this.element = createElement('pswp', 'div');
     this.element.setAttribute('tabindex', '-1');
     this.element.setAttribute('role', 'dialog');
+    this.element.setAttribute('aria-modal', 'true');
 
     // template is legacy prop
     this.template = this.element;


### PR DESCRIPTION
Add's `aria-modal="true"` on the dialog element.

> A section of content is "modal" means navigation is limited to the area itself and the background (the ancestors and siblings of the modal) is hidden. Setting aria-modal="true" on [dialog](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and [alertdialog role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alertdialog_role) containers indicates the presence of a "modal" element to users of assistive technology, but does not actually make the element modal. The features that make the element actually modal must be implemented by the developer.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal