### PR TITLE
fix(photoswape): make the hidden top bar unclickable

### DIFF
--- a/src/photoswipe.css
+++ b/src/photoswipe.css
@@ -277,6 +277,9 @@ div.pswp__img--placeholder,
 	pointer-events: none !important;
 }
 .pswp__top-bar > * {
+  pointer-events: none;
+}
+.pswp--ui-visible .pswp__top-bar > * {
   pointer-events: auto;
   /* this makes transition significantly more smooth,
      even though inner elements are not animated */


### PR DESCRIPTION
When the tapAction click event is set to 'toggle-controls', after the top bar is hidden, the zoom and close buttons can still be clicked. Fixed the issue where the hidden top bar couldn't block clicks.